### PR TITLE
feat(cc-companion): SPEC-HITL-CC-001 Phase 1 — list_phone_tools + call_phone_tool MCP tools

### DIFF
--- a/src/__tests__/audit.test.ts
+++ b/src/__tests__/audit.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { sha256Hex, type AuditEvent } from "../audit.js";
+
+describe("audit.ts", () => {
+  it("sha256Hex returns a stable 64-char hex digest", () => {
+    const h1 = sha256Hex("hello");
+    const h2 = sha256Hex("hello");
+    expect(h1).toBe(h2);
+    expect(h1).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("AuditEvent shape: closed-enum fields accept the spec values", () => {
+    // Compile-time + runtime sanity: a value built from the spec's closed
+    // enums must satisfy the AuditEvent contract.
+    const evt: AuditEvent = {
+      ts: new Date("2026-05-16T12:00:00.000Z").toISOString(),
+      instance_id: "abc-123",
+      direction: "cc_calls_phone",
+      kind: "tool_call",
+      tool_name: "list_events",
+      approval: null,
+      prompt_hash: sha256Hex("{}"),
+      duration_ms: null,
+    };
+    expect(evt.direction).toBe("cc_calls_phone");
+    expect(evt.kind).toBe("tool_call");
+    expect(evt.tool_name).toBe("list_events");
+    expect(evt.approval).toBeNull();
+    expect(evt.duration_ms).toBeNull();
+
+    const resultEvt: AuditEvent = {
+      ...evt,
+      direction: "phone_returns_to_cc",
+      kind: "tool_result",
+      approval: "user_approved",
+      duration_ms: 1234,
+    };
+    expect(resultEvt.approval).toBe("user_approved");
+    expect(resultEvt.duration_ms).toBe(1234);
+  });
+});

--- a/src/__tests__/correlator.test.ts
+++ b/src/__tests__/correlator.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import { FrameCorrelator } from "../correlator.js";
+
+describe("FrameCorrelator", () => {
+  it("resolve() returns the payload to the waiter and clears state", async () => {
+    const c = new FrameCorrelator();
+    const reqId = "req-1";
+    const promise = c.register<{ value: number }>(reqId, 5_000);
+    expect(c.size).toBe(1);
+    expect(c.resolve(reqId, { value: 42 })).toBe(true);
+    expect(c.size).toBe(0);
+    await expect(promise).resolves.toEqual({ value: 42 });
+  });
+
+  it("resolve() of an unknown / already-settled request returns false", () => {
+    const c = new FrameCorrelator();
+    expect(c.resolve("nope", {})).toBe(false);
+    const promise = c.register("req", 5_000);
+    void promise.catch(() => undefined); // suppress unhandled rejection
+    c.resolve("req", {});
+    expect(c.resolve("req", {})).toBe(false);
+  });
+
+  it("register() rejects on timeout and clears state", async () => {
+    const c = new FrameCorrelator();
+    const promise = c.register("req-t", 25);
+    await expect(promise).rejects.toThrow(/timeout/);
+    expect(c.size).toBe(0);
+  });
+
+  it("reject() fires the waiter with the given error", async () => {
+    const c = new FrameCorrelator();
+    const promise = c.register("req-r", 5_000);
+    expect(c.reject("req-r", new Error("conn_dropped"))).toBe(true);
+    await expect(promise).rejects.toThrow(/conn_dropped/);
+    expect(c.size).toBe(0);
+  });
+
+  it("rejectAll() drains every outstanding waiter", async () => {
+    const c = new FrameCorrelator();
+    const p1 = c.register("a", 5_000);
+    const p2 = c.register("b", 5_000);
+    expect(c.size).toBe(2);
+    c.rejectAll(new Error("shutdown"));
+    expect(c.size).toBe(0);
+    await expect(p1).rejects.toThrow(/shutdown/);
+    await expect(p2).rejects.toThrow(/shutdown/);
+  });
+
+  it("register() with a duplicate request_id throws synchronously", () => {
+    const c = new FrameCorrelator();
+    void c.register("dup", 5_000).catch(() => undefined);
+    expect(() => c.register("dup", 5_000)).toThrow(/duplicate/);
+  });
+});

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -1,0 +1,117 @@
+/**
+ * Append-only JSONL audit log per SPEC-HITL-CC-001 §4.2.
+ *
+ * - One file per UTC day: `~/.hitl/channels/audit/<YYYY-MM-DD>.jsonl`.
+ * - Closed schema enforced via the `AuditEvent` type.
+ * - 30-day local retention with oldest-first prune at startup. Pruning is
+ *   best-effort and non-blocking.
+ */
+
+import { homedir } from "node:os";
+import { appendFile, mkdir, readdir, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+
+const AUDIT_DIR = join(homedir(), ".hitl", "channels", "audit");
+const RETENTION_DAYS = 30;
+
+export type AuditDirection =
+  | "phone_to_cc"
+  | "cc_to_phone"
+  | "cc_calls_phone"
+  | "phone_returns_to_cc";
+
+export type AuditKind =
+  | "message"
+  | "pairing_request"
+  | "bootstrap"
+  | "reply"
+  | "choices"
+  | "tool_call"
+  | "tool_result";
+
+export type AuditApproval =
+  | "auto"
+  | "user_approved"
+  | "user_denied"
+  | "timeout"
+  | null;
+
+export interface AuditEvent {
+  ts: string;                    // ISO-8601 UTC
+  instance_id: string;
+  direction: AuditDirection;
+  kind: AuditKind;
+  tool_name: string | null;      // null unless kind ∈ {tool_call, tool_result}
+  approval: AuditApproval;       // null unless kind === 'tool_result'
+  prompt_hash: string;           // SHA-256 hex of content / JSON.stringify(arguments)
+  duration_ms: number | null;    // null unless this is an outbound result
+}
+
+function utcDateStamp(date = new Date()): string {
+  // YYYY-MM-DD in UTC, no time component.
+  return date.toISOString().slice(0, 10);
+}
+
+function fileForDate(date = new Date()): string {
+  return join(AUDIT_DIR, `${utcDateStamp(date)}.jsonl`);
+}
+
+export function sha256Hex(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+/**
+ * Append one event line. Errors are swallowed and logged to stderr — audit
+ * IO must never block the WS path.
+ */
+export async function appendAudit(event: AuditEvent): Promise<void> {
+  try {
+    await mkdir(AUDIT_DIR, { recursive: true });
+    const line = JSON.stringify(event) + "\n";
+    await appendFile(fileForDate(), line, { encoding: "utf8" });
+  } catch (err) {
+    process.stderr.write(
+      `[hitl-channel] audit append failed: ${err instanceof Error ? err.message : err}\n`
+    );
+  }
+}
+
+/**
+ * Oldest-first prune of audit files older than RETENTION_DAYS. Best-effort —
+ * any failure is logged but does not block startup. Returns the number of
+ * files deleted (useful for tests).
+ */
+export async function pruneOldAuditFiles(now = new Date()): Promise<number> {
+  try {
+    await mkdir(AUDIT_DIR, { recursive: true });
+    const entries = await readdir(AUDIT_DIR);
+    const cutoffMs = now.getTime() - RETENTION_DAYS * 24 * 60 * 60 * 1000;
+    let deleted = 0;
+    for (const name of entries) {
+      if (!name.endsWith(".jsonl")) continue;
+      const filePath = join(AUDIT_DIR, name);
+      try {
+        const st = await stat(filePath);
+        if (st.mtimeMs < cutoffMs) {
+          await rm(filePath);
+          deleted++;
+          process.stderr.write(`[hitl-channel] audit pruned ${name}\n`);
+        }
+      } catch (err) {
+        process.stderr.write(
+          `[hitl-channel] audit prune skip ${name}: ${err instanceof Error ? err.message : err}\n`
+        );
+      }
+    }
+    return deleted;
+  } catch (err) {
+    process.stderr.write(
+      `[hitl-channel] audit prune failed: ${err instanceof Error ? err.message : err}\n`
+    );
+    return 0;
+  }
+}
+
+/** Test helper: expose the resolved audit dir. */
+export const auditDir = AUDIT_DIR;

--- a/src/correlator.ts
+++ b/src/correlator.ts
@@ -1,0 +1,81 @@
+/**
+ * Request-ID correlator for round-trip WS frames (tool_call_*, list_tools_*).
+ *
+ * SPEC-HITL-CC-001 §4.2: `pending: Map<requestId, {resolve, reject, timer}>`.
+ * `register(reqId, timeoutMs)` returns a Promise; `resolve(reqId, payload)` and
+ * `reject(reqId, err)` fire from the WS message handler.
+ *
+ * Idempotency note: a result for an unknown or already-resolved request_id is
+ * dropped (the caller is responsible for logging — see server.ts).
+ */
+export class FrameCorrelator {
+  private readonly pending = new Map<
+    string,
+    {
+      resolve: (payload: unknown) => void;
+      reject: (err: Error) => void;
+      timer: ReturnType<typeof setTimeout>;
+    }
+  >();
+
+  /**
+   * Register a pending request. Returns a Promise that resolves when
+   * `resolve(reqId, payload)` is called or rejects on timeout / `reject`.
+   *
+   * Throws synchronously if `reqId` is already registered — callers must
+   * generate fresh UUIDs per request.
+   */
+  register<T = unknown>(reqId: string, timeoutMs: number): Promise<T> {
+    if (this.pending.has(reqId)) {
+      throw new Error(`correlator: duplicate request_id ${reqId}`);
+    }
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(reqId);
+        reject(new Error(`timeout after ${timeoutMs}ms (request_id=${reqId})`));
+      }, timeoutMs);
+      this.pending.set(reqId, {
+        resolve: (payload) => resolve(payload as T),
+        reject,
+        timer,
+      });
+    });
+  }
+
+  /**
+   * Resolve a pending request. Returns `true` if a waiter was resolved,
+   * `false` if the reqId was unknown or already settled.
+   */
+  resolve(reqId: string, payload: unknown): boolean {
+    const entry = this.pending.get(reqId);
+    if (!entry) return false;
+    clearTimeout(entry.timer);
+    this.pending.delete(reqId);
+    entry.resolve(payload);
+    return true;
+  }
+
+  /**
+   * Reject a pending request explicitly (e.g. on connection drop).
+   */
+  reject(reqId: string, err: Error): boolean {
+    const entry = this.pending.get(reqId);
+    if (!entry) return false;
+    clearTimeout(entry.timer);
+    this.pending.delete(reqId);
+    entry.reject(err);
+    return true;
+  }
+
+  /** Test helper: current number of outstanding requests. */
+  get size(): number {
+    return this.pending.size;
+  }
+
+  /** Reject every outstanding request — used on shutdown / disconnect. */
+  rejectAll(err: Error): void {
+    for (const [reqId] of this.pending) {
+      this.reject(reqId, err);
+    }
+  }
+}

--- a/src/http_bridge.ts
+++ b/src/http_bridge.ts
@@ -4,8 +4,31 @@ import { HitlAttachment, HitlMessage, HitlWebSocket, ReplyPayload } from "./type
 import { createPairingRequest, consumePairingCode, validatePairingCode } from "./pairing.js";
 import { addToAllowlist, isTokenAllowed, hashToken } from "./allowlist.js";
 import { getIdentity } from "./identity.js";
+import { FrameCorrelator } from "./correlator.js";
+import { appendAudit, sha256Hex } from "./audit.js";
 
 export const clients = new Set<HitlWebSocket>();
+
+// SPEC-HITL-CC-001 §4.2 — single correlator instance shared with server.ts so
+// inbound `tool_call_result` / `list_tools_result` frames can resolve waiters.
+export const correlator = new FrameCorrelator();
+
+/**
+ * Broadcast a JSON frame to every connected phone WS. Used by `call_phone_tool`
+ * / `list_phone_tools` to push a request frame. Returns the number of clients
+ * the frame was actually delivered to.
+ */
+export function broadcastFrame(frame: Record<string, unknown>): number {
+  const raw = JSON.stringify(frame);
+  let count = 0;
+  for (const ws of clients) {
+    if (ws.readyState === 1) {
+      ws.send(raw);
+      count++;
+    }
+  }
+  return count;
+}
 
 /**
  * Generate a new device token (UUID).
@@ -298,7 +321,48 @@ export function startHttpBridge(mcp: Server) {
       },
       message(_ws, raw) {
         try {
-          const data = JSON.parse(String(raw)) as HitlMessage;
+          const data = JSON.parse(String(raw)) as Record<string, unknown> & HitlMessage;
+          // SPEC-HITL-CC-001 §4.2 — `type`-first routing: control frames must
+          // never fall through to the chat-notification path. A
+          // `tool_call_result` arriving for an unknown / already-resolved
+          // request_id is logged at warn level and dropped (no waiter, no
+          // audit double-count) per the idempotency contract.
+          const frameType = typeof data.type === "string" ? data.type : undefined;
+          if (frameType === "tool_call_result" || frameType === "list_tools_result") {
+            const reqId = typeof data.request_id === "string" ? data.request_id : undefined;
+            if (!reqId) {
+              process.stderr.write(
+                `[hitl-channel] WARN ${frameType} missing request_id — dropped\n`
+              );
+              return;
+            }
+            const resolved = correlator.resolve(reqId, data);
+            if (!resolved) {
+              process.stderr.write(
+                `[hitl-channel] WARN ${frameType} for unknown request_id ${reqId} — dropped\n`
+              );
+              return;
+            }
+            // Async audit; don't block WS path.
+            void appendAudit({
+              ts: new Date().toISOString(),
+              instance_id: process.env.HITL_INSTANCE_ID ?? "unknown",
+              direction: "phone_returns_to_cc",
+              kind: "tool_result",
+              tool_name:
+                frameType === "tool_call_result"
+                  ? (typeof data.tool_name === "string" ? data.tool_name : null)
+                  : null,
+              approval:
+                frameType === "tool_call_result"
+                  ? ((data.approval as "auto" | "user_approved" | "user_denied" | "timeout" | undefined) ?? null)
+                  : null,
+              prompt_hash: sha256Hex(JSON.stringify(data)),
+              duration_ms: null,
+            });
+            return;
+          }
+
           const message = data.message?.trim() || data.content?.trim();
           if (message || (data.attachments && data.attachments.length > 0)) {
             processAttachments(message ?? "", data.attachments)
@@ -313,6 +377,16 @@ export function startHttpBridge(mcp: Server) {
                   `[hitl-channel] Failed to send notification: ${err instanceof Error ? err.message : err}\n`
                 );
               });
+            void appendAudit({
+              ts: new Date().toISOString(),
+              instance_id: process.env.HITL_INSTANCE_ID ?? "unknown",
+              direction: "phone_to_cc",
+              kind: "message",
+              tool_name: null,
+              approval: null,
+              prompt_hash: sha256Hex(message ?? ""),
+              duration_ms: null,
+            });
           }
         } catch {
           // Ignore malformed messages

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,15 +5,43 @@ import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import { startHttpBridge, broadcastReply, clients } from "./http_bridge.js";
+import {
+  startHttpBridge,
+  broadcastReply,
+  broadcastFrame,
+  correlator,
+  clients,
+} from "./http_bridge.js";
 import { getIdentity } from "./identity.js";
 import { startMDNS } from "./mdns.js";
 import { cleanupExpiredPairings } from "./pairing.js";
+import {
+  appendAudit,
+  pruneOldAuditFiles,
+  sha256Hex,
+} from "./audit.js";
+import type {
+  ListToolsResultFrame,
+  ToolCallResultFrame,
+} from "./types.js";
 
 const PORT = Number(process.env.HITL_CHANNEL_PORT ?? 8789);
 
+// SPEC-HITL-CC-001 §4.2 — standing-orders contract APPENDED (not replacing)
+// the existing chat-relay instructions, so Claude Code defaults to the new
+// production tool-call path without a paste-in bootstrap prompt.
+const STANDING_ORDERS = [
+  "Treat inbound channel notifications as user queries from the paired HITL phone.",
+  "For phone-relevant questions or actions (calendar, contacts, agents, navigation, send/compose, file ops, …),",
+  "default to `call_phone_tool(name, arguments)` — see `list_phone_tools()` for the live catalog.",
+  "Trust-tier confirms are gated on the phone UI; you do not need to ask the user for yes/no in chat —",
+  "the user will tap Approve or Deny on a system sheet and the call returns with `approval:` populated.",
+  "When you do speak back to the user, use `reply_to_hitl` with the inbound `message_id`.",
+  "Requires Claude Code v2.1.80+ for `--dangerously-load-development-channels`.",
+].join(" ");
+
 const mcp = new Server(
-  { name: "hitl-channel", version: "0.0.1" },
+  { name: "hitl-channel", version: "0.1.0" },
   {
     capabilities: {
       experimental: { "claude/channel": {} },
@@ -23,6 +51,7 @@ const mcp = new Server(
       'Messages from the HITL mobile app arrive as <channel source="hitl-channel" sender_id="..." message_id="...">.',
       "Use the reply_to_hitl tool to send responses back to the mobile app user.",
       "The sender_id indicates who sent the message (e.g., 'ceo', 'xo').",
+      STANDING_ORDERS,
     ].join(" "),
   }
 );
@@ -78,11 +107,62 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ["prompt", "choices"],
       },
     },
+    // ─── SPEC-HITL-CC-001 Phase 1 ────────────────────────────────────────
+    {
+      name: "list_phone_tools",
+      description:
+        "List the on-device tools available on the paired HITL phone. " +
+        "Returns the catalog of InternalToolsService tools (~60) with name, " +
+        "description, inputSchema, and trust tier (free | softConfirm | hardConfirm). " +
+        "Excludes UI-flow primitives tagged inAppOnly.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          filter: {
+            type: "string",
+            description: "Optional substring filter on tool name.",
+          },
+        },
+      },
+    },
+    {
+      name: "call_phone_tool",
+      description:
+        "Invoke an on-device tool on the paired HITL phone (e.g. list_events, " +
+        "compose_email, navigate_to_agent, create_local_agent). " +
+        "Soft/hard-confirm tools surface the existing trust-tier sheet on the " +
+        "phone; the call returns with approval = 'auto' | 'user_approved' | " +
+        "'user_denied' | 'timeout'. Free-tier tools run silently. " +
+        "Use list_phone_tools() for the live catalog.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+            description: "Tool name (from list_phone_tools).",
+          },
+          arguments: {
+            type: "object",
+            description: "Tool arguments matching the tool's inputSchema.",
+          },
+          timeout_seconds: {
+            type: "number",
+            description: "Round-trip timeout. Default 60, hard cap 300.",
+          },
+        },
+        required: ["name"],
+      },
+    },
   ],
 }));
 
+function generateRequestId(): string {
+  return globalThis.crypto.randomUUID();
+}
+
 mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
   const args = (req.params.arguments ?? {}) as Record<string, unknown>;
+  const identity = await getIdentity();
 
   if (req.params.name === "reply_to_hitl") {
     const text = args.text as string;
@@ -94,6 +174,16 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
     );
 
     broadcastReply(text, messageId, agentId);
+    void appendAudit({
+      ts: new Date().toISOString(),
+      instance_id: identity.instanceId,
+      direction: "cc_to_phone",
+      kind: "reply",
+      tool_name: null,
+      approval: null,
+      prompt_hash: sha256Hex(text ?? ""),
+      duration_ms: null,
+    });
 
     return {
       content: [{ type: "text" as const, text: `Sent to HITL app: ${text}` }],
@@ -109,7 +199,6 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
       `[hitl-channel] Choices: ${prompt} [${choices.join(", ")}] (multi: ${multiSelect ?? false})\n`
     );
 
-    // Broadcast choices to connected apps via WebSocket
     const payload = JSON.stringify({
       type: "choices",
       content: prompt,
@@ -122,10 +211,197 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
     for (const ws of clients) {
       if (ws.readyState === 1) ws.send(payload);
     }
+    void appendAudit({
+      ts: new Date().toISOString(),
+      instance_id: identity.instanceId,
+      direction: "cc_to_phone",
+      kind: "choices",
+      tool_name: null,
+      approval: null,
+      prompt_hash: sha256Hex(prompt ?? ""),
+      duration_ms: null,
+    });
 
     return {
-      content: [{ type: "text" as const, text: `Choices presented to user: ${choices.join(", ")}` }],
+      content: [
+        {
+          type: "text" as const,
+          text: `Choices presented to user: ${choices.join(", ")}`,
+        },
+      ],
     };
+  }
+
+  // ─── SPEC-HITL-CC-001 Phase 1 ─────────────────────────────────────────
+  if (req.params.name === "list_phone_tools") {
+    if (clients.size === 0) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text" as const,
+            text: "No paired HITL phone is currently connected.",
+          },
+        ],
+      };
+    }
+    const filter = (args.filter as string | undefined) ?? undefined;
+    const requestId = generateRequestId();
+    const frame = {
+      type: "list_tools_request" as const,
+      request_id: requestId,
+      ...(filter ? { filter } : {}),
+    };
+    const waiter = correlator.register<ListToolsResultFrame>(requestId, 30_000);
+    const delivered = broadcastFrame(frame);
+    if (delivered === 0) {
+      correlator.reject(requestId, new Error("no_phone_connected_post_check"));
+    }
+    try {
+      const result = await waiter;
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              { tools: result.tools ?? [] },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    } catch (err) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text" as const,
+            text: `list_phone_tools failed: ${err instanceof Error ? err.message : err}`,
+          },
+        ],
+      };
+    }
+  }
+
+  if (req.params.name === "call_phone_tool") {
+    if (clients.size === 0) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text" as const,
+            text: "No paired HITL phone is currently connected.",
+          },
+        ],
+      };
+    }
+    const name = args.name as string | undefined;
+    if (!name || typeof name !== "string") {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text" as const,
+            text: "call_phone_tool requires `name` (string).",
+          },
+        ],
+      };
+    }
+    const toolArgs = (args.arguments as Record<string, unknown> | undefined) ?? {};
+    const rawTimeout = Number(args.timeout_seconds ?? 60);
+    const timeoutSeconds = Math.min(
+      300,
+      Math.max(1, Number.isFinite(rawTimeout) ? rawTimeout : 60),
+    );
+    const requestId = generateRequestId();
+    const frame = {
+      type: "tool_call_request" as const,
+      request_id: requestId,
+      name,
+      arguments: toolArgs,
+      timeout_seconds: timeoutSeconds,
+      cc_instance_id: identity.instanceId,
+    };
+    const startedAt = Date.now();
+    void appendAudit({
+      ts: new Date(startedAt).toISOString(),
+      instance_id: identity.instanceId,
+      direction: "cc_calls_phone",
+      kind: "tool_call",
+      tool_name: name,
+      approval: null,
+      prompt_hash: sha256Hex(JSON.stringify(toolArgs)),
+      duration_ms: null,
+    });
+    const waiter = correlator.register<ToolCallResultFrame>(
+      requestId,
+      timeoutSeconds * 1000,
+    );
+    const delivered = broadcastFrame(frame);
+    if (delivered === 0) {
+      correlator.reject(requestId, new Error("no_phone_connected_post_check"));
+    }
+    try {
+      const result = await waiter;
+      const duration = Date.now() - startedAt;
+      void appendAudit({
+        ts: new Date().toISOString(),
+        instance_id: identity.instanceId,
+        direction: "phone_returns_to_cc",
+        kind: "tool_result",
+        tool_name: name,
+        approval: result.approval ?? null,
+        prompt_hash: sha256Hex(JSON.stringify(result.output ?? null)),
+        duration_ms: duration,
+      });
+      if (result.success === false) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  success: false,
+                  error: result.error ?? "unknown_error",
+                  approval: result.approval ?? null,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      }
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                success: true,
+                output: result.output ?? null,
+                approval: result.approval ?? null,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text" as const,
+            text: `call_phone_tool failed: ${msg}`,
+          },
+        ],
+      };
+    }
   }
 
   throw new Error(`Unknown tool: ${req.params.name}`);
@@ -133,11 +409,17 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
 
 // Initialize instance identity and start services
 const identity = await getIdentity();
+// Propagate to env so http_bridge audit-on-message can stamp instance_id
+// without re-reading the identity file on every WS frame.
+process.env.HITL_INSTANCE_ID = identity.instanceId;
 process.stderr.write(
   `[hitl-channel] HITL Channel server listening on http://0.0.0.0:${PORT}\n`
 );
 process.stderr.write(`[hitl-channel] Instance ID: ${identity.instanceId}\n`);
 process.stderr.write(`[hitl-channel] Display Name: ${identity.displayName}\n`);
+
+// SPEC-HITL-CC-001 §4.2 — best-effort audit retention prune at startup.
+void pruneOldAuditFiles();
 
 // Start mDNS advertising
 startMDNS(PORT, identity.instanceId, identity.displayName);

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,3 +35,51 @@ export interface HitlWebSocket {
   readyState: number;
   send: (data: string) => void;
 }
+
+// ─── SPEC-HITL-CC-001 frame types ──────────────────────────────────────────
+// New WS frame types added by Phase 1 of the Companion Agent spec. All frames
+// are JSON text frames on the existing `/ws` endpoint and co-exist with the
+// pre-existing `reply` / `choices` shapes.
+
+export interface ToolCallRequestFrame {
+  type: "tool_call_request";
+  request_id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+  timeout_seconds: number;
+  cc_instance_id: string;
+}
+
+export interface ToolCallResultFrame {
+  type: "tool_call_result";
+  request_id: string;
+  success: boolean;
+  output?: unknown;
+  error?: string | null;
+  approval?: "auto" | "user_approved" | "user_denied" | "timeout";
+}
+
+export interface ListToolsRequestFrame {
+  type: "list_tools_request";
+  request_id: string;
+  filter?: string;
+}
+
+export interface ListedTool {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  tier: string; // free | softConfirm | hardConfirm
+}
+
+export interface ListToolsResultFrame {
+  type: "list_tools_result";
+  request_id: string;
+  tools: ListedTool[];
+}
+
+export interface BootstrapFrame {
+  type: "bootstrap";
+  content: string;
+  meta: { type: "bootstrap" };
+}


### PR DESCRIPTION
## Summary

Phase 1 of SPEC-HITL-CC-001 — adds two new MCP tools (`list_phone_tools`, `call_phone_tool`) so a paired Claude Code session can reach the ~60 (actually 126 — exceeds spec) on-device `InternalToolsService` tools on the HITL phone. Sibling PR in `hitl-app` adds the on-device handler that dispatches these frames through the existing trust-tier sheet.

- **`src/server.ts`** — appends the standing-orders contract to MCP `instructions` (so vanilla `claude --dangerously-load-development-channels server:hitl-channel` is enough — no per-session paste); registers `list_phone_tools({filter?})` and `call_phone_tool({name, arguments, timeout_seconds?})`.
- **`src/correlator.ts` (NEW)** — `FrameCorrelator` with `register/resolve/reject/rejectAll`, timeout-on-register, duplicate-id rejection. Decoupled from `http_bridge.ts` so each round-trip's Promise resolution is independent.
- **`src/audit.ts` (NEW)** — JSONL audit at `~/.hitl/channels/audit/<YYYY-MM-DD>.jsonl`. Closed schema (`direction`, `kind`, `approval` enums per spec §4.2). 30-day oldest-first prune at startup (best-effort, non-blocking).
- **`src/http_bridge.ts`** — WS message handler routes `tool_call_result` / `list_tools_result` into the correlator (`type`-first routing); chat-shaped frames keep their existing channel-notification path (AC#10 backward-compat). Audit lines emitted on every message / reply / tool_call / tool_result.
- **`broadcastFrame(frame)`** exposed so server-side tool handlers can push request frames to connected phones.
- Idempotency: per-frame `request_id` UUID is generated server-side; phone-side LRU (in `hitl-app` sibling) short-circuits duplicates. Unknown / already-resolved `request_id`s on the return path are logged warn-level and dropped (no waiter, no audit double-count).

## Test plan

New tests pass:
- [x] `src/__tests__/correlator.test.ts` — 6 tests (resolve / reject / timeout / rejectAll / duplicate-id / unknown-id)
- [x] `src/__tests__/audit.test.ts` — 2 tests (sha256 stability + closed-enum shape)

`bun test src/__tests__/correlator.test.ts src/__tests__/audit.test.ts` → 8/8 pass. Pre-existing `server.test.ts` / `pairing-integration.test.ts` port-binding failures are present on the parent branch (verified via `git stash`) — unrelated to this PR.

End-to-end (against the sibling `hitl-app` PR — see `slaser79/hitl-app#3981` for full evidence trail):
- [x] `list_phone_tools` returns 126 tools end-to-end through the bridge
- [x] `call_phone_tool` round-trips correctly with `approval` enum populated (`auto` / `user_approved` / `user_denied`)
- [x] Audit JSONL populated with closed schema, paired call/result entries, duration_ms on outbound results

## SPEC reference

`slaser79/hitl-app:.specs/features/SPEC-HITL-CC-001_claude_code_companion_agent.md` — Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)