### PR TITLE
feat(replay): per-instance ReplyBuffer drains queued replies on WS reconnect

### DIFF
--- a/src/__tests__/reply_buffer.test.ts
+++ b/src/__tests__/reply_buffer.test.ts
@@ -35,6 +35,7 @@ function makeFakeWs(): { ws: HitlWebSocket; sent: string[] } {
     readyState: 1,
     send: (data: string) => {
       sent.push(data);
+      return data.length;
     },
   };
   return { ws, sent };
@@ -242,6 +243,53 @@ describe("ReplyBuffer — SPEC-HITL-CC-001 AC#26", () => {
     expect(r2.sent).toBe(0);
     expect(r2.oldestQueuedAt).toBeNull();
     expect(sent2.length).toBe(0);
+  });
+
+  // ─── P1 regression: ws.send return value gates commit ─────────────────
+  it("P1 regression: failed ws.send result leaves current and remaining entries buffered", () => {
+    const buf = new ReplyBuffer();
+    buf.push(makeReply("a", "m1", "agentA", "1"));
+    buf.push(makeReply("b", "m2", "agentA", "2"));
+    buf.push(makeReply("c", "m3", "agentA", "3"));
+
+    const accepted: string[] = [];
+    let attempts = 0;
+    const ws: HitlWebSocket = {
+      readyState: 1,
+      send: (data: string) => {
+        attempts++;
+        if (attempts === 1) {
+          accepted.push(data);
+          return data.length;
+        }
+        return 0;
+      },
+    };
+
+    const r1 = drainBufferToClientSync(ws, buf);
+    expect(r1.sent).toBe(1);
+    expect(accepted.length).toBe(1);
+    expect(buf.size()).toBe(2);
+
+    const { ws: ws2, sent: sent2 } = makeFakeWs();
+    const r2 = drainBufferToClientSync(ws2, buf);
+    expect(r2.sent).toBe(2);
+    expect(sent2.map((s) => JSON.parse(s).message_id)).toEqual(["m2", "m3"]);
+    expect(buf.size()).toBe(0);
+  });
+
+  // ─── P1 regression: arrival order is monotonic, not wall-clock sorted ─
+  it("P1 regression: clock rollback does not reorder buffered replies", () => {
+    const times = [1_000, 900, 1_100, 1_200];
+    const buf = new ReplyBuffer({ now: () => times.shift()! });
+
+    buf.push(makeReply("first", "m1", "agentA", "1"));
+    buf.push(makeReply("second", "m2", "agentA", "2"));
+    buf.push(makeReply("third", "m3", "agentA", "3"));
+
+    const drained = buf.drain();
+    expect(drained.map((e) => e.queuedAt)).toEqual([1_000, 900, 1_100]);
+    expect(drained.map((e) => e.payload.message_id)).toEqual(["m1", "m2", "m3"]);
   });
 
   // ─── peek/commit contract ─────────────────────────────────────────────

--- a/src/__tests__/reply_buffer.test.ts
+++ b/src/__tests__/reply_buffer.test.ts
@@ -311,4 +311,47 @@ describe("ReplyBuffer — SPEC-HITL-CC-001 AC#26", () => {
     expect(buf.commit(snap1[1]!)).toBe(true);
     expect(buf.size()).toBe(0);
   });
+
+  // ─── R2 P1#1 coverage: ws.send returning -1 (closed) ──────────────────
+  // Different failure mode from the backpressure-drop (return 0) case above:
+  // Bun returns -1 when the socket has already been closed at the OS level.
+  // wsSendAccepted treats both as not-accepted, so the loop bails on the
+  // first attempt and nothing gets committed.
+  it("R2 P1#1: ws.send returning -1 (closed) bails without committing", () => {
+    const buf = new ReplyBuffer();
+    buf.push(makeReply("a", "m1", "agentA", "1"));
+    buf.push(makeReply("b", "m2", "agentA", "2"));
+
+    const ws: HitlWebSocket = {
+      readyState: 1,
+      send: (_data: string): number => -1,
+    };
+
+    const { sent: sentCount } = drainBufferToClientSync(ws, buf);
+    expect(sentCount).toBe(0);
+    expect(buf.size()).toBe(2);             // nothing sent, nothing committed
+  });
+
+  // ─── R2 P1#1 sibling: broadcastReply also gates on send return ────────
+  // wsSendAccepted is applied at the broadcastReply call site too, so a
+  // backpressure-drop on the only OPEN client doesn't suppress the buffer
+  // push and lose the reply.
+  it("R2 P1#1 sibling: broadcastReply pushes to buffer when the only OPEN client backpressure-drops", async () => {
+    const { broadcastReply, clients, replyBuffer } = await import("../http_bridge.js");
+    replyBuffer.drain();   // reset state for test isolation
+
+    const dropping: HitlWebSocket = {
+      readyState: 1,
+      send: (_data: string): number => 0,   // backpressure-drop on every send
+    };
+    clients.add(dropping);
+    try {
+      broadcastReply("hello", "m-bp", "agentBP");
+      const buffered = replyBuffer.drain();
+      expect(buffered.length).toBe(1);
+      expect(buffered[0]!.payload.message_id).toBe("m-bp");
+    } finally {
+      clients.delete(dropping);
+    }
+  });
 });

--- a/src/__tests__/reply_buffer.test.ts
+++ b/src/__tests__/reply_buffer.test.ts
@@ -332,6 +332,39 @@ describe("ReplyBuffer — SPEC-HITL-CC-001 AC#26", () => {
     expect(buf.size()).toBe(2);             // nothing sent, nothing committed
   });
 
+  // ─── R3 P2#2 regression: pre-stringified raw is cached at push time ───
+  it("R3 P2#2: BufferedReply.raw is cached at push time and matches JSON.stringify(payload)", () => {
+    const buf = new ReplyBuffer();
+    const payload = makeReply("hello", "m1", "agentA", "1");
+    buf.push(payload);
+    const [entry] = buf.peek();
+    expect(entry!.raw).toBe(JSON.stringify(payload));
+  });
+
+  // ─── R3 P3#1 regression: Math.min for oldest_buffered_seconds ─────────
+  // Sequence-sort puts the earliest-pushed entry first, but under clock
+  // rollback that entry's queuedAt is NOT the minimum. The audit's
+  // oldest_buffered_seconds must reflect the TRUE minimum wall-clock value.
+  it("R3 P3#1: oldest_buffered_seconds reflects min(queuedAt) under clock rollback", async () => {
+    // Push 3 entries with clock going forward, then backward, then forward.
+    const times = [1_000, 2_000, 500, 1_500];
+    const buf = new ReplyBuffer({ now: () => times.shift()! });
+    buf.push(makeReply("a", "m1", "agentA", "1"));   // queuedAt=1000, seq=0
+    buf.push(makeReply("b", "m2", "agentA", "2"));   // queuedAt=2000, seq=1
+    buf.push(makeReply("c", "m3", "agentA", "3"));   // queuedAt= 500, seq=2 ← oldest by wall-clock
+
+    const { ws } = makeFakeWs();
+    const auditCalls: BufferDrainAuditLine[] = [];
+    const fakeAudit = async (line: BufferDrainAuditLine) => {
+      auditCalls.push(line);
+    };
+
+    // Wall-clock at drain time = 7000ms. Oldest queuedAt = 500. Age = 6.5s → 6s floor.
+    await drainBufferToClient(ws, buf, fakeAudit, () => 7_000);
+    expect(auditCalls.length).toBe(1);
+    expect(auditCalls[0]!.oldest_buffered_seconds).toBe(6);
+  });
+
   // ─── R2 P1#1 sibling: broadcastReply also gates on send return ────────
   // wsSendAccepted is applied at the broadcastReply call site too, so a
   // backpressure-drop on the only OPEN client doesn't suppress the buffer

--- a/src/__tests__/reply_buffer.test.ts
+++ b/src/__tests__/reply_buffer.test.ts
@@ -1,0 +1,155 @@
+/**
+ * SPEC-HITL-CC-001 Phase 4 AC#26 — five named acceptance tests for the
+ * per-instance ReplyBuffer. See hitl-channel#10 for the AC wording.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { ReplyBuffer } from "../reply_buffer.js";
+import { drainBufferToClient } from "../http_bridge.js";
+import type {
+  BufferDrainAuditLine,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- imported for shape sanity
+} from "../audit.js";
+import type { HitlWebSocket, ReplyPayload } from "../types.js";
+
+function makeReply(
+  text: string,
+  messageId: string,
+  agentId?: string,
+  idSuffix = "x",
+): ReplyPayload {
+  return {
+    type: "reply",
+    text,
+    content: text,
+    id: `r-${idSuffix}`,
+    message_id: messageId,
+    agent_id: agentId,
+    ts: new Date().toISOString(),
+  };
+}
+
+function makeFakeWs(): { ws: HitlWebSocket; sent: string[] } {
+  const sent: string[] = [];
+  const ws: HitlWebSocket = {
+    readyState: 1,
+    send: (data: string) => {
+      sent.push(data);
+    },
+  };
+  return { ws, sent };
+}
+
+describe("ReplyBuffer — SPEC-HITL-CC-001 AC#26", () => {
+  // ─── Test 1 ───────────────────────────────────────────────────────────
+  it("Test 1: disconnect → 2 replies → reconnect drains in arrival order", () => {
+    let t = 1_000_000;
+    const buf = new ReplyBuffer({ now: () => t });
+    // Simulate WS-disconnect window: broadcastReply falls through to push().
+    buf.push(makeReply("first", "m1", "agentA", "1"));
+    t += 50;
+    buf.push(makeReply("second", "m2", "agentA", "2"));
+    expect(buf.size()).toBe(2);
+
+    // Simulate WS reconnect: the open handler calls drain().
+    const drained = buf.drain();
+    expect(drained.length).toBe(2);
+    expect(drained.map((e) => e.payload.message_id)).toEqual(["m1", "m2"]);
+    expect(drained.map((e) => e.payload.content)).toEqual(["first", "second"]);
+    // Arrival-order check via received_at timestamps (queuedAt):
+    expect(drained[0].queuedAt).toBeLessThanOrEqual(drained[1].queuedAt);
+    // Buffer must clear after drain.
+    expect(buf.size()).toBe(0);
+  });
+
+  // ─── Test 2 ───────────────────────────────────────────────────────────
+  it("Test 2: FIFO across cap edge — 35 pushed → drain returns last 32", () => {
+    const buf = new ReplyBuffer({ capPerAgent: 32 });
+    for (let i = 1; i <= 35; i++) {
+      buf.push(makeReply(`r${i}`, `m${i}`, "agentA", String(i)));
+    }
+    const drained = buf.drain();
+    expect(drained.length).toBe(32);
+    // Oldest 3 (m1, m2, m3) must have been evicted FIFO.
+    expect(drained[0].payload.message_id).toBe("m4");
+    expect(drained[drained.length - 1].payload.message_id).toBe("m35");
+  });
+
+  // ─── Test 3 ───────────────────────────────────────────────────────────
+  it("Test 3: TTL — fake clock past 24h drops expired entries before drain", () => {
+    let t = 1_000_000;
+    const buf = new ReplyBuffer({ ttlMs: 24 * 60 * 60 * 1000, now: () => t });
+    buf.push(makeReply("hello", "m1", "agentA", "1"));
+    buf.push(makeReply("world", "m2", "agentA", "2"));
+    expect(buf.size()).toBe(2);
+    // Advance fake clock past 24h.
+    t += 25 * 60 * 60 * 1000;
+    const drained = buf.drain();
+    expect(drained.length).toBe(0);
+    expect(buf.size()).toBe(0);
+  });
+
+  // ─── Test 4 ───────────────────────────────────────────────────────────
+  it("Test 4: cross-instance isolation — buffer A does not drain to buffer B", () => {
+    const instanceA = new ReplyBuffer();
+    const instanceB = new ReplyBuffer();
+    instanceA.push(makeReply("from A", "mA", "agentA", "A"));
+    instanceB.push(makeReply("from B", "mB", "agentB", "B"));
+
+    const drainedA = instanceA.drain();
+    expect(drainedA.length).toBe(1);
+    expect(drainedA[0].payload.message_id).toBe("mA");
+    expect(drainedA[0].payload.agent_id).toBe("agentA");
+
+    const drainedB = instanceB.drain();
+    expect(drainedB.length).toBe(1);
+    expect(drainedB[0].payload.message_id).toBe("mB");
+    expect(drainedB[0].payload.agent_id).toBe("agentB");
+  });
+
+  // ─── Test 5 ───────────────────────────────────────────────────────────
+  it("Test 5: emits phone_offline_buffer_drain audit line with replies_drained + oldest_buffered_seconds", async () => {
+    let t = 1_000_000;
+    const buf = new ReplyBuffer({ now: () => t });
+    buf.push(makeReply("a", "m1", "agentA", "1"));
+    t += 100;
+    buf.push(makeReply("b", "m2", "agentA", "2"));
+    t += 100;
+    buf.push(makeReply("c", "m3", "agentA", "3"));
+
+    // Advance the "wall clock" feeding drainBufferToClient so the oldest
+    // entry registers as 7 seconds old at drain time.
+    const drainWallClockMs = t + 7_000;
+
+    const { ws, sent } = makeFakeWs();
+    const auditCalls: BufferDrainAuditLine[] = [];
+    const fakeAudit = async (line: BufferDrainAuditLine) => {
+      auditCalls.push(line);
+    };
+
+    const n = await drainBufferToClient(ws, buf, fakeAudit, () => drainWallClockMs);
+    expect(n).toBe(3);
+    expect(sent.length).toBe(3);
+
+    expect(auditCalls.length).toBe(1);
+    const line = auditCalls[0]!;
+    expect(line.event).toBe("phone_offline_buffer_drain");
+    expect(line.replies_drained).toBe(3);
+    expect(line.oldest_buffered_seconds).toBe(7);
+    expect(typeof line.instance_id).toBe("string");
+    expect(line.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  // ─── Guard: empty drain does NOT emit an audit line ───────────────────
+  it("guard: empty buffer does not emit a phone_offline_buffer_drain audit line", async () => {
+    const buf = new ReplyBuffer();
+    const { ws } = makeFakeWs();
+    const auditCalls: BufferDrainAuditLine[] = [];
+    const fakeAudit = async (line: BufferDrainAuditLine) => {
+      auditCalls.push(line);
+    };
+    const n = await drainBufferToClient(ws, buf, fakeAudit);
+    expect(n).toBe(0);
+    expect(auditCalls.length).toBe(0);
+  });
+});

--- a/src/__tests__/reply_buffer.test.ts
+++ b/src/__tests__/reply_buffer.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, expect, it } from "bun:test";
 import { ReplyBuffer } from "../reply_buffer.js";
-import { drainBufferToClient } from "../http_bridge.js";
+import { drainBufferToClient, drainBufferToClientSync } from "../http_bridge.js";
 import type {
   BufferDrainAuditLine,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- imported for shape sanity
@@ -151,5 +151,116 @@ describe("ReplyBuffer — SPEC-HITL-CC-001 AC#26", () => {
     const n = await drainBufferToClient(ws, buf, fakeAudit);
     expect(n).toBe(0);
     expect(auditCalls.length).toBe(0);
+  });
+
+  // ─── P0 regression: peek + per-entry commit ───────────────────────────
+  // The buffer used to call `drain()` (destructive clear) BEFORE confirming
+  // ws.send succeeded. If the WS dropped mid-loop, remaining entries were
+  // permanently lost. peek + commit now leaves un-sent entries in the buffer.
+  it("P0 regression: partial-send (ws dies mid-loop) leaves remaining entries in buffer", () => {
+    const buf = new ReplyBuffer();
+    buf.push(makeReply("a", "m1", "agentA", "1"));
+    buf.push(makeReply("b", "m2", "agentA", "2"));
+    buf.push(makeReply("c", "m3", "agentA", "3"));
+    expect(buf.size()).toBe(3);
+
+    // Fake WS that closes after the first send.
+    const sent: string[] = [];
+    let sendCount = 0;
+    const ws: HitlWebSocket = {
+      readyState: 1,
+      send: (data: string) => {
+        sent.push(data);
+        sendCount++;
+        if (sendCount >= 1) ws.readyState = 3; // CLOSED after first send
+      },
+    };
+
+    const { sent: sentCount } = drainBufferToClientSync(ws, buf);
+    expect(sentCount).toBe(1);          // only the first entry was sent
+    expect(sent.length).toBe(1);
+    expect(buf.size()).toBe(2);         // m2 + m3 still in buffer for next reconnect
+
+    // Second reconnect: a healthy WS drains the rest.
+    const { ws: ws2, sent: sent2 } = makeFakeWs();
+    const r2 = drainBufferToClientSync(ws2, buf);
+    expect(r2.sent).toBe(2);
+    expect(sent2.length).toBe(2);
+    const ids = sent2.map((s) => JSON.parse(s).message_id);
+    expect(ids).toEqual(["m2", "m3"]);
+    expect(buf.size()).toBe(0);
+  });
+
+  // ─── P2 regression: audit `replies_drained` reflects actual sends ─────
+  it("P2 regression: audit replies_drained counts actual ws.send successes, not peek snapshot length", async () => {
+    const buf = new ReplyBuffer();
+    buf.push(makeReply("a", "m1", "agentA", "1"));
+    buf.push(makeReply("b", "m2", "agentA", "2"));
+    buf.push(makeReply("c", "m3", "agentA", "3"));
+
+    // Fake WS that dies after 2 sends.
+    const sent: string[] = [];
+    let sendCount = 0;
+    const ws: HitlWebSocket = {
+      readyState: 1,
+      send: (data: string) => {
+        sent.push(data);
+        sendCount++;
+        if (sendCount >= 2) ws.readyState = 3;
+      },
+    };
+
+    const auditCalls: BufferDrainAuditLine[] = [];
+    const fakeAudit = async (line: BufferDrainAuditLine) => {
+      auditCalls.push(line);
+    };
+
+    const n = await drainBufferToClient(ws, buf, fakeAudit, () => Date.now());
+    expect(n).toBe(2);                       // 2 actually sent
+    expect(auditCalls.length).toBe(1);
+    expect(auditCalls[0]!.replies_drained).toBe(2); // not 3 (the peek snapshot length)
+    expect(buf.size()).toBe(1);              // m3 still buffered
+  });
+
+  // ─── P1#2 regression: concurrent drains are safe ──────────────────────
+  // Removing the `clients.size === 1` guard relies on peek+commit being
+  // idempotent: a second drainer sees an empty buffer (the first drainer
+  // already committed every entry) and returns zero. No double-send, no
+  // audit double-emit.
+  it("P1#2 regression: a second sync drain on the same buffer returns zero and emits no double-send", () => {
+    const buf = new ReplyBuffer();
+    buf.push(makeReply("a", "m1", "agentA", "1"));
+    buf.push(makeReply("b", "m2", "agentA", "2"));
+
+    const { ws: ws1, sent: sent1 } = makeFakeWs();
+    const r1 = drainBufferToClientSync(ws1, buf);
+    expect(r1.sent).toBe(2);
+    expect(sent1.length).toBe(2);
+
+    const { ws: ws2, sent: sent2 } = makeFakeWs();
+    const r2 = drainBufferToClientSync(ws2, buf);
+    expect(r2.sent).toBe(0);
+    expect(r2.oldestQueuedAt).toBeNull();
+    expect(sent2.length).toBe(0);
+  });
+
+  // ─── peek/commit contract ─────────────────────────────────────────────
+  it("peek does not remove entries; commit removes a specific entry by reference", () => {
+    const buf = new ReplyBuffer();
+    buf.push(makeReply("a", "m1", "agentA", "1"));
+    buf.push(makeReply("b", "m2", "agentA", "2"));
+
+    const snap1 = buf.peek();
+    expect(snap1.length).toBe(2);
+    expect(buf.size()).toBe(2);             // peek did NOT remove
+
+    const snap2 = buf.peek();
+    expect(snap2.length).toBe(2);           // peek is idempotent
+
+    expect(buf.commit(snap1[0]!)).toBe(true);
+    expect(buf.size()).toBe(1);
+    expect(buf.commit(snap1[0]!)).toBe(false); // double-commit is safe (idempotent)
+    expect(buf.commit(snap1[1]!)).toBe(true);
+    expect(buf.size()).toBe(0);
   });
 });

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -78,6 +78,37 @@ export async function appendAudit(event: AuditEvent): Promise<void> {
 }
 
 /**
+ * SPEC-HITL-CC-001 Phase 4 AC#26 — distinct audit line shape for ReplyBuffer
+ * drains. Emitted on each non-empty drain (i.e. when ≥1 buffered reply was
+ * replayed to a reconnecting client). Lives in the same daily JSONL file as
+ * AuditEvent but uses its own closed schema, discriminated by the `event`
+ * field.
+ */
+export interface BufferDrainAuditLine {
+  ts: string;                       // ISO-8601 UTC
+  instance_id: string;
+  event: "phone_offline_buffer_drain";
+  replies_drained: number;          // count of entries replayed
+  oldest_buffered_seconds: number;  // floor((now - oldest.queuedAt) / 1000)
+}
+
+/**
+ * Append one `phone_offline_buffer_drain` line. Same fire-and-forget shape
+ * as appendAudit — failures are logged to stderr but never block the WS path.
+ */
+export async function appendBufferDrainAudit(line: BufferDrainAuditLine): Promise<void> {
+  try {
+    await mkdir(AUDIT_DIR, { recursive: true });
+    const raw = JSON.stringify(line) + "\n";
+    await appendFile(fileForDate(), raw, { encoding: "utf8" });
+  } catch (err) {
+    process.stderr.write(
+      `[hitl-channel] buffer-drain audit append failed: ${err instanceof Error ? err.message : err}\n`
+    );
+  }
+}
+
+/**
  * Oldest-first prune of audit files older than RETENTION_DAYS. Best-effort —
  * any failure is logged but does not block startup. Returns the number of
  * files deleted (useful for tests).

--- a/src/http_bridge.ts
+++ b/src/http_bridge.ts
@@ -139,11 +139,19 @@ export function drainBufferToClientSync(
 ): { sent: number; oldestQueuedAt: number | null } {
   const peeked = buffer.peek();
   if (peeked.length === 0) return { sent: 0, oldestQueuedAt: null };
-  const oldestQueuedAt = peeked[0]!.queuedAt;
+  // sequence-sort puts the earliest-pushed entry first, but under clock
+  // rollback that entry's queuedAt is NOT necessarily the minimum — scan
+  // the whole peek to find the true oldest wall-clock value for audit.
+  let oldestQueuedAt = peeked[0]!.queuedAt;
+  for (const e of peeked) {
+    if (e.queuedAt < oldestQueuedAt) oldestQueuedAt = e.queuedAt;
+  }
   let sent = 0;
   for (const entry of peeked) {
     if (ws.readyState !== 1) break;
-    if (!wsSendAccepted(ws, JSON.stringify(entry.payload))) break;
+    // entry.raw is the JSON.stringify(payload) cached at push time —
+    // re-using it avoids re-serializing on every reconnect.
+    if (!wsSendAccepted(ws, entry.raw)) break;
     buffer.commit(entry);
     sent++;
   }

--- a/src/http_bridge.ts
+++ b/src/http_bridge.ts
@@ -112,12 +112,42 @@ export function broadcastReply(text: string, messageId?: string, agentId?: strin
 }
 
 /**
- * SPEC-HITL-CC-001 Phase 4 AC#26 — drain `buffer` to `ws` in arrival order
- * and emit one `phone_offline_buffer_drain` audit line per non-empty drain.
- * Expired entries (past TTL) are silently dropped, not replayed.
+ * SPEC-HITL-CC-001 Phase 4 AC#26 — synchronously send buffered replies to
+ * `ws` in arrival order, removing each entry from `buffer` ONLY AFTER
+ * `ws.send` succeeds (peek + per-entry commit). If `ws.readyState`
+ * transitions out of OPEN mid-loop, remaining entries stay in the buffer
+ * for replay on the next reconnect.
  *
- * The `audit` parameter is injected for test isolation (default = the real
- * appendBufferDrainAudit). Returns the number of entries actually sent.
+ * This function is intentionally synchronous (no awaits) so that callers
+ * invoking it from a Bun WS `open` handler are guaranteed all sends finish
+ * before any subsequent `broadcastReply` call can race on the new client —
+ * Bun runs handlers single-threaded and cannot interleave between
+ * `clients.add(ws)` and this loop's completion.
+ *
+ * Returns `{sent, oldestQueuedAt}`. `oldestQueuedAt` is null when `sent === 0`.
+ */
+export function drainBufferToClientSync(
+  ws: HitlWebSocket,
+  buffer: ReplyBuffer = replyBuffer,
+): { sent: number; oldestQueuedAt: number | null } {
+  const peeked = buffer.peek();
+  if (peeked.length === 0) return { sent: 0, oldestQueuedAt: null };
+  const oldestQueuedAt = peeked[0]!.queuedAt;
+  let sent = 0;
+  for (const entry of peeked) {
+    if (ws.readyState !== 1) break;
+    ws.send(JSON.stringify(entry.payload));
+    buffer.commit(entry);
+    sent++;
+  }
+  return { sent, oldestQueuedAt: sent > 0 ? oldestQueuedAt : null };
+}
+
+/**
+ * Async wrapper around drainBufferToClientSync that also emits the
+ * `phone_offline_buffer_drain` audit line. The `audit` parameter is
+ * injected for test isolation. Returns the number of entries actually sent
+ * to `ws` (matches the value of `replies_drained` in the emitted audit line).
  */
 export async function drainBufferToClient(
   ws: HitlWebSocket,
@@ -125,23 +155,17 @@ export async function drainBufferToClient(
   audit: (line: BufferDrainAuditLine) => Promise<void> = appendBufferDrainAudit,
   nowMs: () => number = () => Date.now(),
 ): Promise<number> {
-  if (buffer.size() === 0) return 0;
-  const drained = buffer.drain();
-  if (drained.length === 0) return 0;
-  const oldestSeconds = Math.max(0, Math.floor((nowMs() - drained[0].queuedAt) / 1000));
-  for (const entry of drained) {
-    if (ws.readyState === 1) {
-      ws.send(JSON.stringify(entry.payload));
-    }
-  }
+  const { sent, oldestQueuedAt } = drainBufferToClientSync(ws, buffer);
+  if (sent === 0 || oldestQueuedAt === null) return 0;
+  const oldestSeconds = Math.max(0, Math.floor((nowMs() - oldestQueuedAt) / 1000));
   await audit({
     ts: new Date().toISOString(),
     instance_id: process.env.HITL_INSTANCE_ID ?? "unknown",
     event: "phone_offline_buffer_drain",
-    replies_drained: drained.length,
+    replies_drained: sent,
     oldest_buffered_seconds: oldestSeconds,
   });
-  return drained.length;
+  return sent;
 }
 
 /**
@@ -361,12 +385,29 @@ export function startHttpBridge(mcp: Server) {
         const typedWs = ws as unknown as HitlWebSocket;
         clients.add(typedWs);
         process.stderr.write(`[hitl-channel] Client connected (${clients.size} total)\n`);
-        // SPEC-HITL-CC-001 Phase 4 AC#26 — drain only on the FIRST reconnect
-        // so a second concurrent client doesn't double-replay the buffer.
-        if (clients.size === 1) {
-          void drainBufferToClient(typedWs).catch((err) => {
+        // SPEC-HITL-CC-001 Phase 4 AC#26 — replay queued replies SYNCHRONOUSLY
+        // before this open handler yields. Bun runs WS event handlers on a
+        // single thread, so no `broadcastReply` call can interleave between
+        // `clients.add(ws)` above and the sync send loop here. Peek+commit
+        // makes the drain idempotent against concurrent reconnects (a second
+        // client's open handler will peek an empty buffer and return zero),
+        // so the guard for `clients.size === 1` is unnecessary and would
+        // wrongly skip the drain when a stale client lingers in `clients`.
+        const { sent, oldestQueuedAt } = drainBufferToClientSync(typedWs);
+        if (sent > 0 && oldestQueuedAt !== null) {
+          const oldestSeconds = Math.max(
+            0,
+            Math.floor((Date.now() - oldestQueuedAt) / 1000),
+          );
+          void appendBufferDrainAudit({
+            ts: new Date().toISOString(),
+            instance_id: process.env.HITL_INSTANCE_ID ?? "unknown",
+            event: "phone_offline_buffer_drain",
+            replies_drained: sent,
+            oldest_buffered_seconds: oldestSeconds,
+          }).catch((err) => {
             process.stderr.write(
-              `[hitl-channel] buffer drain failed: ${err instanceof Error ? err.message : err}\n`
+              `[hitl-channel] buffer drain audit failed: ${err instanceof Error ? err.message : err}\n`
             );
           });
         }

--- a/src/http_bridge.ts
+++ b/src/http_bridge.ts
@@ -5,13 +5,19 @@ import { createPairingRequest, consumePairingCode, validatePairingCode } from ".
 import { addToAllowlist, isTokenAllowed, hashToken } from "./allowlist.js";
 import { getIdentity } from "./identity.js";
 import { FrameCorrelator } from "./correlator.js";
-import { appendAudit, sha256Hex } from "./audit.js";
+import { appendAudit, appendBufferDrainAudit, sha256Hex, type BufferDrainAuditLine } from "./audit.js";
+import { ReplyBuffer } from "./reply_buffer.js";
 
 export const clients = new Set<HitlWebSocket>();
 
 // SPEC-HITL-CC-001 §4.2 — single correlator instance shared with server.ts so
 // inbound `tool_call_result` / `list_tools_result` frames can resolve waiters.
 export const correlator = new FrameCorrelator();
+
+// SPEC-HITL-CC-001 Phase 4 AC#26 — per-instance ReplyBuffer. Replies that
+// arrive while no WS clients are connected get queued here and drained on the
+// next WS reconnect (see `drainBufferToClient` + the WS `open` handler).
+export const replyBuffer = new ReplyBuffer();
 
 /**
  * Broadcast a JSON frame to every connected phone WS. Used by `call_phone_tool`
@@ -91,11 +97,51 @@ export function broadcastReply(text: string, messageId?: string, agentId?: strin
     ts: new Date().toISOString(),
   };
   const rawPayload = JSON.stringify(payload);
+  let sent = 0;
   for (const ws of clients) {
     if (ws.readyState === 1) {
       ws.send(rawPayload);
+      sent++;
     }
   }
+  // SPEC-HITL-CC-001 Phase 4 AC#26 — instead of silently dropping when no
+  // OPEN WS client received the frame, queue for replay on next WS reconnect.
+  if (sent === 0) {
+    replyBuffer.push(payload);
+  }
+}
+
+/**
+ * SPEC-HITL-CC-001 Phase 4 AC#26 — drain `buffer` to `ws` in arrival order
+ * and emit one `phone_offline_buffer_drain` audit line per non-empty drain.
+ * Expired entries (past TTL) are silently dropped, not replayed.
+ *
+ * The `audit` parameter is injected for test isolation (default = the real
+ * appendBufferDrainAudit). Returns the number of entries actually sent.
+ */
+export async function drainBufferToClient(
+  ws: HitlWebSocket,
+  buffer: ReplyBuffer = replyBuffer,
+  audit: (line: BufferDrainAuditLine) => Promise<void> = appendBufferDrainAudit,
+  nowMs: () => number = () => Date.now(),
+): Promise<number> {
+  if (buffer.size() === 0) return 0;
+  const drained = buffer.drain();
+  if (drained.length === 0) return 0;
+  const oldestSeconds = Math.max(0, Math.floor((nowMs() - drained[0].queuedAt) / 1000));
+  for (const entry of drained) {
+    if (ws.readyState === 1) {
+      ws.send(JSON.stringify(entry.payload));
+    }
+  }
+  await audit({
+    ts: new Date().toISOString(),
+    instance_id: process.env.HITL_INSTANCE_ID ?? "unknown",
+    event: "phone_offline_buffer_drain",
+    replies_drained: drained.length,
+    oldest_buffered_seconds: oldestSeconds,
+  });
+  return drained.length;
 }
 
 /**
@@ -312,8 +358,18 @@ export function startHttpBridge(mcp: Server) {
     },
     websocket: {
       open(ws) {
-        clients.add(ws as unknown as HitlWebSocket);
+        const typedWs = ws as unknown as HitlWebSocket;
+        clients.add(typedWs);
         process.stderr.write(`[hitl-channel] Client connected (${clients.size} total)\n`);
+        // SPEC-HITL-CC-001 Phase 4 AC#26 — drain only on the FIRST reconnect
+        // so a second concurrent client doesn't double-replay the buffer.
+        if (clients.size === 1) {
+          void drainBufferToClient(typedWs).catch((err) => {
+            process.stderr.write(
+              `[hitl-channel] buffer drain failed: ${err instanceof Error ? err.message : err}\n`
+            );
+          });
+        }
       },
       close(ws) {
         clients.delete(ws as unknown as HitlWebSocket);

--- a/src/http_bridge.ts
+++ b/src/http_bridge.ts
@@ -19,6 +19,15 @@ export const correlator = new FrameCorrelator();
 // next WS reconnect (see `drainBufferToClient` + the WS `open` handler).
 export const replyBuffer = new ReplyBuffer();
 
+function wsSendAccepted(ws: HitlWebSocket, data: string): boolean {
+  try {
+    const result = ws.send(data);
+    return typeof result !== "number" || result > 0;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Broadcast a JSON frame to every connected phone WS. Used by `call_phone_tool`
  * / `list_phone_tools` to push a request frame. Returns the number of clients
@@ -28,8 +37,7 @@ export function broadcastFrame(frame: Record<string, unknown>): number {
   const raw = JSON.stringify(frame);
   let count = 0;
   for (const ws of clients) {
-    if (ws.readyState === 1) {
-      ws.send(raw);
+    if (ws.readyState === 1 && wsSendAccepted(ws, raw)) {
       count++;
     }
   }
@@ -99,8 +107,7 @@ export function broadcastReply(text: string, messageId?: string, agentId?: strin
   const rawPayload = JSON.stringify(payload);
   let sent = 0;
   for (const ws of clients) {
-    if (ws.readyState === 1) {
-      ws.send(rawPayload);
+    if (ws.readyState === 1 && wsSendAccepted(ws, rawPayload)) {
       sent++;
     }
   }
@@ -136,7 +143,7 @@ export function drainBufferToClientSync(
   let sent = 0;
   for (const entry of peeked) {
     if (ws.readyState !== 1) break;
-    ws.send(JSON.stringify(entry.payload));
+    if (!wsSendAccepted(ws, JSON.stringify(entry.payload))) break;
     buffer.commit(entry);
     sent++;
   }

--- a/src/http_bridge.ts
+++ b/src/http_bridge.ts
@@ -392,32 +392,21 @@ export function startHttpBridge(mcp: Server) {
         const typedWs = ws as unknown as HitlWebSocket;
         clients.add(typedWs);
         process.stderr.write(`[hitl-channel] Client connected (${clients.size} total)\n`);
-        // SPEC-HITL-CC-001 Phase 4 AC#26 — replay queued replies SYNCHRONOUSLY
-        // before this open handler yields. Bun runs WS event handlers on a
-        // single thread, so no `broadcastReply` call can interleave between
-        // `clients.add(ws)` above and the sync send loop here. Peek+commit
+        // SPEC-HITL-CC-001 Phase 4 AC#26 — replay queued replies to this
+        // client. drainBufferToClient invokes drainBufferToClientSync first
+        // (no awaits before the ws.send loop), so all sends complete before
+        // the async wrapper yields to await the audit emit. Bun runs WS
+        // handlers single-threaded, so no broadcastReply can interleave
+        // between `clients.add(ws)` above and the sync send loop. Peek+commit
         // makes the drain idempotent against concurrent reconnects (a second
-        // client's open handler will peek an empty buffer and return zero),
-        // so the guard for `clients.size === 1` is unnecessary and would
+        // client's open handler peeks an empty buffer and returns zero), so
+        // the previous `clients.size === 1` guard is unnecessary and would
         // wrongly skip the drain when a stale client lingers in `clients`.
-        const { sent, oldestQueuedAt } = drainBufferToClientSync(typedWs);
-        if (sent > 0 && oldestQueuedAt !== null) {
-          const oldestSeconds = Math.max(
-            0,
-            Math.floor((Date.now() - oldestQueuedAt) / 1000),
+        void drainBufferToClient(typedWs).catch((err) => {
+          process.stderr.write(
+            `[hitl-channel] buffer drain failed: ${err instanceof Error ? err.message : err}\n`
           );
-          void appendBufferDrainAudit({
-            ts: new Date().toISOString(),
-            instance_id: process.env.HITL_INSTANCE_ID ?? "unknown",
-            event: "phone_offline_buffer_drain",
-            replies_drained: sent,
-            oldest_buffered_seconds: oldestSeconds,
-          }).catch((err) => {
-            process.stderr.write(
-              `[hitl-channel] buffer drain audit failed: ${err instanceof Error ? err.message : err}\n`
-            );
-          });
-        }
+        });
       },
       close(ws) {
         clients.delete(ws as unknown as HitlWebSocket);

--- a/src/reply_buffer.ts
+++ b/src/reply_buffer.ts
@@ -63,6 +63,7 @@ export class ReplyBuffer {
     }
     bucket.push({
       payload,
+      raw: JSON.stringify(payload),
       queuedAt: this.nowFn(),
       sequence: this.nextSequence++,
     });

--- a/src/reply_buffer.ts
+++ b/src/reply_buffer.ts
@@ -24,6 +24,10 @@ const DEFAULT_CAP_PER_AGENT = 32;
 /** SPEC-HITL-CC-001 R2: 24h TTL. */
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
 
+interface BufferedReplyEntry extends BufferedReply {
+  sequence: number;
+}
+
 export interface ReplyBufferOptions {
   /** Override the per-agent_id ring cap (default 32). */
   capPerAgent?: number;
@@ -34,10 +38,11 @@ export interface ReplyBufferOptions {
 }
 
 export class ReplyBuffer {
-  private readonly buckets = new Map<string, BufferedReply[]>();
+  private readonly buckets = new Map<string, BufferedReplyEntry[]>();
   private readonly cap: number;
   private readonly ttlMs: number;
   private readonly nowFn: () => number;
+  private nextSequence = 0;
 
   constructor(opts: ReplyBufferOptions = {}) {
     this.cap = opts.capPerAgent ?? DEFAULT_CAP_PER_AGENT;
@@ -56,7 +61,11 @@ export class ReplyBuffer {
       bucket = [];
       this.buckets.set(key, bucket);
     }
-    bucket.push({ payload, queuedAt: this.nowFn() });
+    bucket.push({
+      payload,
+      queuedAt: this.nowFn(),
+      sequence: this.nextSequence++,
+    });
     while (bucket.length > this.cap) {
       bucket.shift();
     }
@@ -74,11 +83,11 @@ export class ReplyBuffer {
    */
   peek(): BufferedReply[] {
     this.evictExpired();
-    const all: BufferedReply[] = [];
+    const all: BufferedReplyEntry[] = [];
     for (const bucket of this.buckets.values()) {
       all.push(...bucket);
     }
-    all.sort((a, b) => a.queuedAt - b.queuedAt);
+    all.sort((a, b) => a.sequence - b.sequence);
     return all;
   }
 
@@ -92,7 +101,7 @@ export class ReplyBuffer {
     const key = entry.payload.agent_id ?? "";
     const bucket = this.buckets.get(key);
     if (!bucket) return false;
-    const idx = bucket.indexOf(entry);
+    const idx = bucket.indexOf(entry as BufferedReplyEntry);
     if (idx === -1) return false;
     bucket.splice(idx, 1);
     if (bucket.length === 0) this.buckets.delete(key);

--- a/src/reply_buffer.ts
+++ b/src/reply_buffer.ts
@@ -1,0 +1,85 @@
+/**
+ * Per-instance in-memory ring buffer for WS replies queued while no clients
+ * are connected. SPEC-HITL-CC-001 Phase 4 AC#26.
+ *
+ * - Keyed on `agent_id` (empty string when unset).
+ * - Bucket cap = 32 (R2). FIFO eviction once a bucket exceeds the cap.
+ * - Entry TTL = 24h (R2). Expired entries are dropped at drain time, never
+ *   replayed.
+ * - In-memory only — daemon restart clears the buffer (acceptable since
+ *   hitl-channel runs alongside CC on the user's desktop; restart is rare
+ *   and explicit per umbrella issue hitl-app#4043).
+ * - Cross-instance isolation: each ReplyBuffer holds its own buckets, so
+ *   two daemons (or two test fixtures) never share state.
+ */
+
+import type { BufferedReply, ReplyPayload } from "./types.js";
+
+/** SPEC-HITL-CC-001 R2: per-agent cap. */
+const DEFAULT_CAP_PER_AGENT = 32;
+/** SPEC-HITL-CC-001 R2: 24h TTL. */
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+
+export interface ReplyBufferOptions {
+  /** Override the per-agent_id ring cap (default 32). */
+  capPerAgent?: number;
+  /** Override the entry TTL in ms (default 24h). */
+  ttlMs?: number;
+  /** Test-only: override the time source (default Date.now). */
+  now?: () => number;
+}
+
+export class ReplyBuffer {
+  private readonly buckets = new Map<string, BufferedReply[]>();
+  private readonly cap: number;
+  private readonly ttlMs: number;
+  private readonly nowFn: () => number;
+
+  constructor(opts: ReplyBufferOptions = {}) {
+    this.cap = opts.capPerAgent ?? DEFAULT_CAP_PER_AGENT;
+    this.ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS;
+    this.nowFn = opts.now ?? (() => Date.now());
+  }
+
+  /**
+   * Queue a reply for later replay. Bucketed by `payload.agent_id`. When a
+   * bucket exceeds the cap, the oldest entry in that bucket is evicted FIFO.
+   */
+  push(payload: ReplyPayload): void {
+    const key = payload.agent_id ?? "";
+    let bucket = this.buckets.get(key);
+    if (!bucket) {
+      bucket = [];
+      this.buckets.set(key, bucket);
+    }
+    bucket.push({ payload, queuedAt: this.nowFn() });
+    while (bucket.length > this.cap) {
+      bucket.shift();
+    }
+  }
+
+  /**
+   * Drain every live (non-expired) entry across all agent_id buckets in
+   * arrival order. The buffer is fully cleared on return — expired entries
+   * are dropped silently and never replayed.
+   */
+  drain(): BufferedReply[] {
+    const cutoff = this.nowFn() - this.ttlMs;
+    const live: BufferedReply[] = [];
+    for (const bucket of this.buckets.values()) {
+      for (const entry of bucket) {
+        if (entry.queuedAt >= cutoff) live.push(entry);
+      }
+    }
+    this.buckets.clear();
+    live.sort((a, b) => a.queuedAt - b.queuedAt);
+    return live;
+  }
+
+  /** Total entries currently buffered across all agent_id buckets (incl. expired). */
+  size(): number {
+    let n = 0;
+    for (const bucket of this.buckets.values()) n += bucket.length;
+    return n;
+  }
+}

--- a/src/reply_buffer.ts
+++ b/src/reply_buffer.ts
@@ -4,13 +4,17 @@
  *
  * - Keyed on `agent_id` (empty string when unset).
  * - Bucket cap = 32 (R2). FIFO eviction once a bucket exceeds the cap.
- * - Entry TTL = 24h (R2). Expired entries are dropped at drain time, never
- *   replayed.
+ * - Entry TTL = 24h (R2). Expired entries are dropped at peek/drain time,
+ *   never replayed.
  * - In-memory only — daemon restart clears the buffer (acceptable since
  *   hitl-channel runs alongside CC on the user's desktop; restart is rare
  *   and explicit per umbrella issue hitl-app#4043).
  * - Cross-instance isolation: each ReplyBuffer holds its own buckets, so
  *   two daemons (or two test fixtures) never share state.
+ *
+ * Production delivery via WS uses peek() + per-entry commit() so a WS that
+ * drops mid-loop leaves un-sent entries in the buffer for the next reconnect.
+ * Tests and shutdown paths can use drain() as a convenience (peek + commit-all).
  */
 
 import type { BufferedReply, ReplyPayload } from "./types.js";
@@ -59,20 +63,55 @@ export class ReplyBuffer {
   }
 
   /**
-   * Drain every live (non-expired) entry across all agent_id buckets in
-   * arrival order. The buffer is fully cleared on return — expired entries
-   * are dropped silently and never replayed.
+   * Snapshot of live (non-expired) entries in arrival order. Expired entries
+   * are pruned as a side effect. Buffer state is otherwise NOT modified —
+   * callers MUST invoke commit(entry) for each successfully delivered entry
+   * to remove it from the buffer.
+   *
+   * This is the contract that protects against partial-send failure: a WS
+   * that drops mid-loop leaves uncommitted entries in the buffer for the
+   * next reconnect.
+   */
+  peek(): BufferedReply[] {
+    this.evictExpired();
+    const all: BufferedReply[] = [];
+    for (const bucket of this.buckets.values()) {
+      all.push(...bucket);
+    }
+    all.sort((a, b) => a.queuedAt - b.queuedAt);
+    return all;
+  }
+
+  /**
+   * Remove a specific entry from the buffer (identified by reference equality
+   * on the BufferedReply object returned from peek). Returns true if the
+   * entry was found and removed; false if it was already absent (idempotent
+   * against double-commit / concurrent drainers).
+   */
+  commit(entry: BufferedReply): boolean {
+    const key = entry.payload.agent_id ?? "";
+    const bucket = this.buckets.get(key);
+    if (!bucket) return false;
+    const idx = bucket.indexOf(entry);
+    if (idx === -1) return false;
+    bucket.splice(idx, 1);
+    if (bucket.length === 0) this.buckets.delete(key);
+    return true;
+  }
+
+  /**
+   * Convenience: peek + commit-all in one call. Returns live entries in
+   * arrival order and removes them from the buffer. Expired entries are
+   * dropped silently.
+   *
+   * Production WS delivery MUST use peek + per-entry commit so partial-send
+   * failures (ws.readyState != OPEN mid-loop) don't lose data. This helper
+   * is for tests, shutdown, and any path that has already confirmed receipt
+   * for the entire batch.
    */
   drain(): BufferedReply[] {
-    const cutoff = this.nowFn() - this.ttlMs;
-    const live: BufferedReply[] = [];
-    for (const bucket of this.buckets.values()) {
-      for (const entry of bucket) {
-        if (entry.queuedAt >= cutoff) live.push(entry);
-      }
-    }
-    this.buckets.clear();
-    live.sort((a, b) => a.queuedAt - b.queuedAt);
+    const live = this.peek();
+    for (const entry of live) this.commit(entry);
     return live;
   }
 
@@ -81,5 +120,18 @@ export class ReplyBuffer {
     let n = 0;
     for (const bucket of this.buckets.values()) n += bucket.length;
     return n;
+  }
+
+  /** Drop expired entries from every bucket. Pure pruning — no replay. */
+  private evictExpired(): void {
+    const cutoff = this.nowFn() - this.ttlMs;
+    for (const [key, bucket] of this.buckets) {
+      const live = bucket.filter((e) => e.queuedAt >= cutoff);
+      if (live.length === 0) {
+        this.buckets.delete(key);
+      } else if (live.length !== bucket.length) {
+        this.buckets.set(key, live);
+      }
+    }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,7 @@ export interface ReplyPayload {
 
 export interface HitlWebSocket {
   readyState: number;
-  send: (data: string) => void;
+  send: (data: string) => number | void;
 }
 
 // ─── SPEC-HITL-CC-001 frame types ──────────────────────────────────────────

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,11 @@ export interface BootstrapFrame {
 export interface BufferedReply {
   /** The reply frame to replay on drain. */
   payload: ReplyPayload;
+  /**
+   * Pre-stringified `payload` cached at push time. Sent verbatim during
+   * drain so we don't re-serialize on every reconnect.
+   */
+  raw: string;
   /** Wall-clock ms epoch when push() was called. Used for TTL + drain age. */
   queuedAt: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,3 +83,14 @@ export interface BootstrapFrame {
   content: string;
   meta: { type: "bootstrap" };
 }
+
+// ─── SPEC-HITL-CC-001 Phase 4 AC#26 — ReplyBuffer types ───────────────────
+// Per-instance in-memory ring buffer for replies that arrive while no WS
+// clients are connected. Entries drain in arrival order on WS reconnect.
+
+export interface BufferedReply {
+  /** The reply frame to replay on drain. */
+  payload: ReplyPayload;
+  /** Wall-clock ms epoch when push() was called. Used for TTL + drain age. */
+  queuedAt: number;
+}


### PR DESCRIPTION
## Summary

SPEC-HITL-CC-001 Phase 4 AC#26 — PR B of the slim Phase 4 rollout (umbrella: `slaser79/hitl-app#4043`). Phone-side pieces (AC#27/28/28a) shipped as PR A in `slaser79/hitl-app#4049`.

Replaces `broadcastReply`'s silent-drop branch (`http_bridge.ts:94-98` on `main`) with a per-instance in-memory ring buffer:

- `ReplyBuffer` class (`src/reply_buffer.ts`): keyed on `agent_id`, cap **32 per agent_id** (R2), TTL **24h** (R2), in-memory only.
- `broadcastReply`: when zero OPEN WS clients received the frame, push to the buffer instead of dropping silently.
- WS `open` handler: on the **first** reconnect (`clients.size === 1`), call `drainBufferToClient`, which sends every live entry in arrival order and emits one `phone_offline_buffer_drain` audit line (`{replies_drained, oldest_buffered_seconds}`) per non-empty drain.
- Expired entries (past TTL) are silently dropped at drain time, never replayed.
- `BufferDrainAuditLine` is a distinct closed-schema shape in `src/audit.ts`, discriminated from `AuditEvent` by the `event` field.

## Files touched

| File | Change |
|---|---|
| `src/reply_buffer.ts` | **new** — ring buffer class |
| `src/types.ts` | `+ BufferedReply` type |
| `src/audit.ts` | `+ BufferDrainAuditLine` type + `appendBufferDrainAudit` writer |
| `src/http_bridge.ts` | wire `replyBuffer.push()` into `broadcastReply` (no-clients path); add `drainBufferToClient` helper; wire into WS `open` |
| `src/__tests__/reply_buffer.test.ts` | **new** — 5 named tests + 1 empty-drain guard |

Total: ~100 LOC TS + tests, as scoped.

## Test plan

Six tests, all green locally (`bun test src/__tests__/reply_buffer.test.ts`):

- [x] **Test 1** — disconnect → 2 replies → reconnect drains in arrival order
- [x] **Test 2** — FIFO across cap edge: 35 pushed → drain returns last 32 (m4…m35)
- [x] **Test 3** — TTL: fake clock advanced past 24h → drain returns 0, buffer is empty
- [x] **Test 4** — Cross-instance isolation: two `ReplyBuffer` instances do not share buckets
- [x] **Test 5** — emits `phone_offline_buffer_drain` audit line with `replies_drained` + `oldest_buffered_seconds`
- [x] **Guard** — empty buffer does NOT emit an audit line

Package-wide `bun test`: 52 pass / 3 fail / 2 errors — **all 3 failures + 2 errors are pre-existing on `main`** (port-in-use race in `pairing-integration.test.ts`, verified by running the same file against `origin/main` in a separate worktree).

## Cross-repo reference

Part of `slaser79/hitl-app#4043` (umbrella). Sibling PR A (already merged): `slaser79/hitl-app#4049`.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)