### PR TITLE
feat(channel): attachments on reply_to_hitl + image content blocks on call_phone_tool result

### DIFF
--- a/src/http_bridge.ts
+++ b/src/http_bridge.ts
@@ -94,7 +94,12 @@ async function isAuthenticated(req: Request): Promise<{ valid: boolean; reason?:
   return { valid: false, reason: "invalid_token" };
 }
 
-export function broadcastReply(text: string, messageId?: string, agentId?: string): void {
+export function broadcastReply(
+  text: string,
+  messageId?: string,
+  agentId?: string,
+  attachments?: HitlAttachment[],
+): void {
   const payload: ReplyPayload = {
     type: "reply",
     text,
@@ -103,6 +108,7 @@ export function broadcastReply(text: string, messageId?: string, agentId?: strin
     message_id: messageId,
     agent_id: agentId,
     ts: new Date().toISOString(),
+    ...(attachments && attachments.length > 0 ? { attachments } : {}),
   };
   const rawPayload = JSON.stringify(payload);
   let sent = 0;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,7 @@
 #!/usr/bin/env bun
+import { readFile, stat } from "node:fs/promises";
+import { basename, extname, resolve as resolvePath } from "node:path";
+import { homedir, tmpdir } from "node:os";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -211,10 +214,42 @@ const MIME_BY_EXT: Record<string, string> = {
   mov: "video/quicktime",
 };
 
+// Per-attachment file-read cap. Matches the spec's 5 MB per-attachment
+// limit (SPEC-HITL-CC-001 AC#35) and bounds memory pressure if a caller
+// supplies an absurdly large file path. Bigger files are rejected at
+// stat time, before any base64 encoding.
+const kMaxFileReadBytes = 5 * 1024 * 1024;
+
+// Allowlist of directory prefixes a `path` attachment may resolve under.
+// Defaults to the user's home directory + tmpdir; an operator can widen
+// or narrow via HITL_CHANNEL_ATTACHMENT_ROOTS (colon-separated absolute
+// paths). The check uses `path.resolve` to normalise away `..` segments
+// before the prefix match so a caller can't escape via `~/../etc/passwd`.
+function attachmentRoots(): string[] {
+  const env = process.env.HITL_CHANNEL_ATTACHMENT_ROOTS;
+  if (env && env.trim().length > 0) {
+    return env
+      .split(":")
+      .map((p) => p.trim())
+      .filter((p) => p.length > 0)
+      .map((p) => resolvePath(p));
+  }
+  return [resolvePath(homedir()), resolvePath(tmpdir())];
+}
+
+function isPathAllowed(absolute: string, roots: string[]): boolean {
+  for (const root of roots) {
+    if (absolute === root) return true;
+    // Append a separator to the root so /home/foo doesn't match /home/foobar.
+    const prefix = root.endsWith("/") ? root : root + "/";
+    if (absolute.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
 async function resolveAttachments(raw: unknown): Promise<HitlAttachment[]> {
   if (!Array.isArray(raw)) return [];
-  const { readFile } = await import("node:fs/promises");
-  const { basename, extname } = await import("node:path");
+  const roots = attachmentRoots();
   const out: HitlAttachment[] = [];
   for (const att of raw) {
     if (att == null || typeof att !== "object") continue;
@@ -231,17 +266,37 @@ async function resolveAttachments(raw: unknown): Promise<HitlAttachment[]> {
     let fileName =
       typeof a.fileName === "string" ? a.fileName : undefined;
     if (typeof a.path === "string" && a.path.length > 0) {
+      const absolute = resolvePath(a.path);
+      if (!isPathAllowed(absolute, roots)) {
+        process.stderr.write(
+          `[hitl-channel] reply_to_hitl: rejecting path outside allowlisted roots: ${absolute}\n`,
+        );
+        continue;
+      }
       try {
-        const buf = await readFile(a.path);
+        const st = await stat(absolute);
+        if (!st.isFile()) {
+          process.stderr.write(
+            `[hitl-channel] reply_to_hitl: path is not a regular file: ${absolute}\n`,
+          );
+          continue;
+        }
+        if (st.size > kMaxFileReadBytes) {
+          process.stderr.write(
+            `[hitl-channel] reply_to_hitl: attachment_too_large size=${st.size} max=${kMaxFileReadBytes} path=${absolute}\n`,
+          );
+          continue;
+        }
+        const buf = await readFile(absolute);
         data = buf.toString("base64");
-        if (!fileName) fileName = basename(a.path);
+        if (!fileName) fileName = basename(absolute);
         if (!mediaType) {
-          const ext = extname(a.path).slice(1).toLowerCase();
+          const ext = extname(absolute).slice(1).toLowerCase();
           mediaType = MIME_BY_EXT[ext] ?? "application/octet-stream";
         }
       } catch (err) {
         process.stderr.write(
-          `[hitl-channel] reply_to_hitl: failed to read ${a.path}: ${
+          `[hitl-channel] reply_to_hitl: failed to read ${absolute}: ${
             err instanceof Error ? err.message : String(err)
           }\n`,
         );
@@ -249,6 +304,12 @@ async function resolveAttachments(raw: unknown): Promise<HitlAttachment[]> {
       }
     } else if (typeof a.data === "string" && a.data.length > 0) {
       data = a.data;
+      // When the caller supplies pre-encoded bytes via `data` and omits
+      // `media_type`, default to a generic binary type rather than
+      // silently dropping the entry. The phone-side codec uses this
+      // for `type` inference; falling back to octet-stream keeps the
+      // attachment round-tripping as a file-chip rather than disappearing.
+      if (!mediaType) mediaType = "application/octet-stream";
     } else {
       continue;
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,7 @@ import {
   summariseAttachments,
 } from "./audit.js";
 import type {
+  HitlAttachment,
   ListToolsResultFrame,
   ToolCallResultFrame,
 } from "./types.js";
@@ -50,7 +51,10 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
       name: "reply_to_hitl",
       description:
         "Send a reply message back to the HITL mobile app user. " +
-        "Pass the message_id from the inbound channel tag for threading.",
+        "Pass the message_id from the inbound channel tag for threading. " +
+        "Optionally include image/file attachments — they render inline " +
+        "on the phone CC chat (images = thumbnail + tap-to-zoom; other " +
+        "mime types = filename chip).",
       inputSchema: {
         type: "object",
         properties: {
@@ -65,6 +69,51 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
           agent_id: {
             type: "string",
             description: "Optional agent identity for multi-instance routing",
+          },
+          attachments: {
+            type: "array",
+            description:
+              "Optional attachments to render in the phone chat bubble. " +
+              "Prefer `path` (absolute filesystem path on the channel host) — " +
+              "the server reads the file and encodes it. Use `data` (base64) " +
+              "only for in-memory bytes you've already encoded. " +
+              "Per-attachment cap 5 MB; per-frame cap 20 MB (decoded). " +
+              "Oversize attachments are dropped phone-side with a warning.",
+            items: {
+              type: "object",
+              properties: {
+                path: {
+                  type: "string",
+                  description:
+                    "Absolute filesystem path. Channel reads + base64-encodes. " +
+                    "If omitted, `data` is required.",
+                },
+                type: {
+                  type: "string",
+                  description:
+                    "'image' or 'file'. If omitted, inferred from media_type. " +
+                    "Image attachments render inline; files render as a " +
+                    "filename chip with mime icon.",
+                },
+                media_type: {
+                  type: "string",
+                  description:
+                    "MIME type (e.g. 'image/png', 'application/pdf'). " +
+                    "If omitted with `path`, inferred from file extension.",
+                },
+                data: {
+                  type: "string",
+                  description:
+                    "Base64-encoded attachment bytes. Ignored if `path` is set.",
+                },
+                fileName: {
+                  type: "string",
+                  description:
+                    "Optional filename for chip rendering. If omitted with " +
+                    "`path`, derived from the path's basename.",
+                },
+              },
+            },
           },
         },
         required: ["text"],
@@ -148,6 +197,79 @@ function generateRequestId(): string {
   return globalThis.crypto.randomUUID();
 }
 
+const MIME_BY_EXT: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  pdf: "application/pdf",
+  txt: "text/plain",
+  json: "application/json",
+  csv: "text/csv",
+  mp4: "video/mp4",
+  mov: "video/quicktime",
+};
+
+async function resolveAttachments(raw: unknown): Promise<HitlAttachment[]> {
+  if (!Array.isArray(raw)) return [];
+  const { readFile } = await import("node:fs/promises");
+  const { basename, extname } = await import("node:path");
+  const out: HitlAttachment[] = [];
+  for (const att of raw) {
+    if (att == null || typeof att !== "object") continue;
+    const a = att as {
+      path?: unknown;
+      type?: unknown;
+      media_type?: unknown;
+      data?: unknown;
+      fileName?: unknown;
+    };
+    let data: string | undefined;
+    let mediaType =
+      typeof a.media_type === "string" ? a.media_type : undefined;
+    let fileName =
+      typeof a.fileName === "string" ? a.fileName : undefined;
+    if (typeof a.path === "string" && a.path.length > 0) {
+      try {
+        const buf = await readFile(a.path);
+        data = buf.toString("base64");
+        if (!fileName) fileName = basename(a.path);
+        if (!mediaType) {
+          const ext = extname(a.path).slice(1).toLowerCase();
+          mediaType = MIME_BY_EXT[ext] ?? "application/octet-stream";
+        }
+      } catch (err) {
+        process.stderr.write(
+          `[hitl-channel] reply_to_hitl: failed to read ${a.path}: ${
+            err instanceof Error ? err.message : String(err)
+          }\n`,
+        );
+        continue;
+      }
+    } else if (typeof a.data === "string" && a.data.length > 0) {
+      data = a.data;
+    } else {
+      continue;
+    }
+    if (!mediaType) continue;
+    const type =
+      typeof a.type === "string" && a.type.length > 0
+        ? a.type
+        : mediaType.startsWith("image/")
+          ? "image"
+          : "file";
+    const entry: HitlAttachment = {
+      type,
+      media_type: mediaType,
+      data,
+    };
+    if (fileName) entry.fileName = fileName;
+    out.push(entry);
+  }
+  return out;
+}
+
 mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
   const args = (req.params.arguments ?? {}) as Record<string, unknown>;
   const identity = await getIdentity();
@@ -156,12 +278,18 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
     const text = args.text as string;
     const messageId = args.message_id as string | undefined;
     const agentId = args.agent_id as string | undefined;
+    const rawAttachments = args.attachments;
+    const attachments: HitlAttachment[] = await resolveAttachments(
+      rawAttachments,
+    );
+    const { count: attachmentCount, bytes: attachmentBytes } =
+      summariseAttachments(attachments);
 
     process.stderr.write(
-      `[hitl-channel] Reply: ${text} (msg: ${messageId}, agent: ${agentId})\n`
+      `[hitl-channel] Reply: ${text} (msg: ${messageId}, agent: ${agentId}, attachments: ${attachmentCount})\n`
     );
 
-    broadcastReply(text, messageId, agentId);
+    broadcastReply(text, messageId, agentId, attachments);
     void appendAudit({
       ts: new Date().toISOString(),
       instance_id: identity.instanceId,
@@ -171,13 +299,17 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
       approval: null,
       prompt_hash: sha256Hex(text ?? ""),
       duration_ms: null,
-      // No attachments on reply frames today (issue #12 closed-schema default).
-      attachment_count: 0,
-      attachment_bytes: 0,
+      attachment_count: attachmentCount,
+      attachment_bytes: attachmentBytes,
     });
 
     return {
-      content: [{ type: "text" as const, text: `Sent to HITL app: ${text}` }],
+      content: [
+        {
+          type: "text" as const,
+          text: `Sent to HITL app: ${text} (attachments: ${attachmentCount})`,
+        },
+      ],
     };
   }
 
@@ -383,22 +515,46 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
           ],
         };
       }
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify(
-              {
-                success: true,
-                output: result.output ?? null,
-                approval: result.approval ?? null,
-              },
-              null,
-              2,
-            ),
-          },
-        ],
-      };
+      const content: Array<
+        | { type: "text"; text: string }
+        | { type: "image"; data: string; mimeType: string }
+      > = [
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              success: true,
+              output: result.output ?? null,
+              approval: result.approval ?? null,
+              attachment_count: attachmentCount,
+              attachment_bytes: attachmentBytes,
+            },
+            null,
+            2,
+          ),
+        },
+      ];
+      const rawAttachments = (result as { attachments?: unknown }).attachments;
+      if (Array.isArray(rawAttachments)) {
+        for (const att of rawAttachments) {
+          if (
+            att != null &&
+            typeof att === "object" &&
+            typeof (att as { type?: unknown }).type === "string" &&
+            (att as { type: string }).type === "image" &&
+            typeof (att as { data?: unknown }).data === "string" &&
+            typeof (att as { media_type?: unknown }).media_type === "string"
+          ) {
+            const a = att as { data: string; media_type: string };
+            content.push({
+              type: "image" as const,
+              data: a.data,
+              mimeType: a.media_type,
+            });
+          }
+        }
+      }
+      return { content };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export interface ReplyPayload {
   message_id?: string;
   agent_id?: string;
   ts: string;
+  attachments?: HitlAttachment[];
 }
 
 export interface HitlWebSocket {


### PR DESCRIPTION
## Summary

Closes the TS-side of the SPEC-HITL-CC-001 Phase 6 attachment contract (the Dart side shipped via `hitl-app#4040`). Two surfaces:

1. **`reply_to_hitl` accepts `attachments[]`** and stamps them on the WS reply frame. Schema lets callers pass either `path` (absolute filesystem path — the channel reads + base64-encodes; CC never inlines bytes into a tool argument) or `data` (pre-encoded base64). `type` / `media_type` / `fileName` inferred from the file extension when omitted alongside `path`.
2. **`call_phone_tool` surfaces inbound `tool_call_result.attachments`** to CC as MCP `image` content blocks alongside the existing text payload. Previously the handler stringified only `{success, output, approval}` and dropped the attachments array — meaning CC saw `"Successfully loaded 1 image(s)."` text but never the rendered bytes.

Audit envelopes already carried `attachment_count` / `attachment_bytes` post-#13; this PR populates them on the `cc_to_phone` reply direction (was hard-coded `0/0` with an issue-#12 TODO comment).

## Verification

On-device 2026-05-18 (Galaxy SM S938B, paired HITL Root):

**AC#37 R1 — outbound `tool_call_result` attachments (PASS):**

```
call_phone_tool({ name:"display_image", arguments:{ urls:[wikimedia dice png] } })
→ { success:true, output:"Successfully loaded 1 image(s).", approval:"auto",
    attachment_count:1, attachment_bytes:224566 }
→ CC also receives an MCP image content block; dice PNG renders inline.
```

flutter.log on the phone side:
```
[CC-toolcall] tool_call_result sent=ok success=true approval=auto
                                 attachment_count=1 attachment_bytes=224566
```

**AC#37 R2 — inbound `reply_to_hitl` attachments (TS side PASS):**

```
reply_to_hitl({ text:"...", attachments:[{ path:"/tmp/r2_dice.png" }] })
→ channel reads file, base64-encodes, broadcasts attachments[] on reply
```

Phone-side codec decode confirmed via flutter.log:
```
[CC-attachments] inbound raw runtimeType=List<dynamic> isList=true length=1
[CC-attachments] decodeList returned 1 entries from 1 raw
[CC-attachments] calling addMessage repo=true attachmentsJson_len=299502
```

A separate renderer gap surfaced (`ClaudeCodeMessageAdapter` doesn't read `attachmentsJson` for agent-side messages) — tracked at [slaser79/hitl-app#4078](https://github.com/slaser79/hitl-app/issues/4078), out of scope for this PR.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Test suite: 71 pass / 3 pre-existing baseline fails (server.stop undefined on pairing-integration tests — unrelated to this diff)
- [ ] On-device verification reproducible against a paired device with PR companions: this + `hitl-app#4079` (display_image remote-callable)

## Refs

- Closes part of #12 (the audit-fields part is already shipped at #13; this completes the matching outbound surfaces)
- Companion: hitl-app#4040 (Phase 6 Dart-side), hitl-app#4079 (display_image remote-callable)
- Follow-up: hitl-app#4078 (adapter renderer wiring — phone-side, distinct repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)