### PR TITLE
feat(channel): SPEC-HC-004 present_questions_to_hitl + questions_batch WS frames

### DIFF
--- a/src/__tests__/audit.test.ts
+++ b/src/__tests__/audit.test.ts
@@ -46,4 +46,20 @@ describe("audit.ts", () => {
     expect(resultEvt.attachment_count).toBe(2);
     expect(resultEvt.attachment_bytes).toBe(4_096);
   });
+
+  it("AuditKind accepts the new SPEC-HC-004 `questions_batch` variant", () => {
+    const evt: AuditEvent = {
+      ts: new Date("2026-05-20T00:00:00.000Z").toISOString(),
+      instance_id: "abc-123",
+      direction: "cc_to_phone",
+      kind: "questions_batch",
+      tool_name: null,
+      approval: null,
+      prompt_hash: sha256Hex("[]"),
+      duration_ms: null,
+      attachment_count: 0,
+      attachment_bytes: 0,
+    };
+    expect(evt.kind).toBe("questions_batch");
+  });
 });

--- a/src/__tests__/questions_batch.test.ts
+++ b/src/__tests__/questions_batch.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "bun:test";
+import { FrameCorrelator } from "../correlator.js";
+import {
+  PRESENT_QUESTIONS_TOOL_DEFINITION,
+  presentQuestionsToHitl,
+  validateQuestionsArgs,
+} from "../questions_batch.js";
+import type { AuditEvent } from "../audit.js";
+import type {
+  QuestionsBatchRequestFrame,
+  QuestionsBatchResultFrame,
+} from "../types.js";
+
+const validQuestion = () => ({
+  header: "Mode",
+  question: "Pick a mode",
+  choices: ["A", "B"],
+});
+
+function makeHandlerDeps() {
+  const correlator = new FrameCorrelator();
+  const emittedFrames: Record<string, unknown>[] = [];
+  const auditRows: AuditEvent[] = [];
+  let nextRequestId = "req-fixed-uuid";
+  const deps = {
+    correlator,
+    broadcastFrame: (frame: Record<string, unknown>) => {
+      emittedFrames.push(frame);
+      return 1;
+    },
+    clientsSize: () => 1,
+    instanceId: "instance-test",
+    generateRequestId: () => nextRequestId,
+    audit: async (e: AuditEvent) => {
+      auditRows.push(e);
+    },
+    now: () => new Date("2026-05-20T00:00:00.000Z"),
+    setRequestId: (id: string) => {
+      nextRequestId = id;
+    },
+  };
+  return { correlator, emittedFrames, auditRows, deps };
+}
+
+describe("validateQuestionsArgs", () => {
+  it("rejects empty questions list", () => {
+    const r = validateQuestionsArgs({ questions: [] });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/at least/);
+  });
+
+  it("rejects > 4 questions", () => {
+    const r = validateQuestionsArgs({
+      questions: [validQuestion(), validQuestion(), validQuestion(), validQuestion(), validQuestion()],
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/exceeds max length 4/);
+  });
+
+  it("rejects < 2 choices", () => {
+    const r = validateQuestionsArgs({
+      questions: [{ ...validQuestion(), choices: ["only"] }],
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/choices must have at least 2/);
+  });
+
+  it("rejects > 4 choices", () => {
+    const r = validateQuestionsArgs({
+      questions: [
+        { ...validQuestion(), choices: ["a", "b", "c", "d", "e"] },
+      ],
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/choices exceeds max length 4/);
+  });
+
+  it("rejects header longer than 12 chars", () => {
+    const r = validateQuestionsArgs({
+      questions: [{ ...validQuestion(), header: "WayTooLongHeaderHere" }],
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/header exceeds max length 12/);
+  });
+
+  it("accepts a well-formed batch with multi_select + allow_other", () => {
+    const r = validateQuestionsArgs({
+      questions: [
+        {
+          header: "Mode",
+          question: "Pick a mode",
+          choices: ["A", "B"],
+          multi_select: true,
+          allow_other: true,
+        },
+      ],
+      timeout_seconds: 30,
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.questions.length).toBe(1);
+      expect(r.questions[0]!.multi_select).toBe(true);
+      expect(r.questions[0]!.allow_other).toBe(true);
+      expect(r.timeoutSeconds).toBe(30);
+    }
+  });
+
+  it("clamps timeout to hard cap 900s", () => {
+    const r = validateQuestionsArgs({
+      questions: [validQuestion()],
+      timeout_seconds: 99999,
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.timeoutSeconds).toBe(900);
+  });
+});
+
+describe("PRESENT_QUESTIONS_TOOL_DEFINITION", () => {
+  it("exposes the schema constraints expected by SPEC-HC-004 AV1", () => {
+    const def = PRESENT_QUESTIONS_TOOL_DEFINITION;
+    expect(def.name).toBe("present_questions_to_hitl");
+    expect(def.inputSchema.properties.questions.minItems).toBe(1);
+    expect(def.inputSchema.properties.questions.maxItems).toBe(4);
+    const item = def.inputSchema.properties.questions.items;
+    expect(item.properties.choices.minItems).toBe(2);
+    expect(item.properties.choices.maxItems).toBe(4);
+    expect(item.properties.header.maxLength).toBe(12);
+  });
+});
+
+describe("presentQuestionsToHitl handler (AV2/AV3/AV6/AV7)", () => {
+  it("happy-path: dispatches one frame, registers waiter, resolves on result", async () => {
+    const { correlator, emittedFrames, auditRows, deps } = makeHandlerDeps();
+    const handlerPromise = presentQuestionsToHitl(
+      { questions: [validQuestion()] },
+      deps,
+    );
+
+    // Exactly one frame should have been emitted before we await.
+    await Promise.resolve(); // let the synchronous part of the handler run
+    expect(emittedFrames.length).toBe(1);
+    const frame = emittedFrames[0] as unknown as QuestionsBatchRequestFrame;
+    expect(frame.type).toBe("questions_batch_request");
+    expect(frame.request_id).toBe("req-fixed-uuid");
+    expect(frame.questions.length).toBe(1);
+    expect(correlator.size).toBe(1);
+
+    // Simulate the phone replying.
+    const reply: QuestionsBatchResultFrame = {
+      type: "questions_batch_result",
+      request_id: frame.request_id,
+      answers: [{ header: "Mode", selected: ["A"] }],
+      cancelled: false,
+    };
+    correlator.resolve(frame.request_id, reply);
+
+    const result = await handlerPromise;
+    expect(result.isError).toBeUndefined();
+    const payload = JSON.parse(result.content[0]!.text);
+    expect(payload.cancelled).toBe(false);
+    expect(payload.answers).toEqual([{ header: "Mode", selected: ["A"] }]);
+    expect(correlator.size).toBe(0);
+
+    // AV3 dispatch-side audit row exists with the right shape.
+    expect(auditRows.length).toBe(1);
+    expect(auditRows[0]!.direction).toBe("cc_to_phone");
+    expect(auditRows[0]!.kind).toBe("questions_batch");
+    expect(auditRows[0]!.tool_name).toBeNull();
+    expect(auditRows[0]!.attachment_count).toBe(0);
+    expect(auditRows[0]!.attachment_bytes).toBe(0);
+    expect(auditRows[0]!.prompt_hash.length).toBe(64);
+  });
+
+  it("AV6: timeout rejects waiter and surfaces error to MCP caller", async () => {
+    const { correlator, deps } = makeHandlerDeps();
+    const result = await presentQuestionsToHitl(
+      { questions: [validQuestion()], timeout_seconds: 0.01 },
+      deps,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toMatch(/timeout/);
+    expect(correlator.size).toBe(0);
+  });
+
+  it("AV7: connection drop (rejectAll) surfaces to MCP caller", async () => {
+    const { correlator, deps } = makeHandlerDeps();
+    const handlerPromise = presentQuestionsToHitl(
+      { questions: [validQuestion()] },
+      deps,
+    );
+    await Promise.resolve();
+    correlator.rejectAll(new Error("phone_disconnected"));
+    const result = await handlerPromise;
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toMatch(/phone_disconnected/);
+  });
+
+  it("returns an error and skips dispatch when no phone is connected", async () => {
+    const { emittedFrames, deps } = makeHandlerDeps();
+    deps.clientsSize = () => 0;
+    const result = await presentQuestionsToHitl(
+      { questions: [validQuestion()] },
+      deps,
+    );
+    expect(result.isError).toBe(true);
+    expect(emittedFrames.length).toBe(0);
+  });
+
+  it("rejects malformed input with no frame emitted", async () => {
+    const { emittedFrames, deps } = makeHandlerDeps();
+    const result = await presentQuestionsToHitl({ questions: [] }, deps);
+    expect(result.isError).toBe(true);
+    expect(emittedFrames.length).toBe(0);
+  });
+});

--- a/src/__tests__/questions_batch_ws.test.ts
+++ b/src/__tests__/questions_batch_ws.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, beforeAll, afterAll } from "bun:test";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { correlator, startHttpBridge } from "../http_bridge.js";
+import type { QuestionsBatchResultFrame } from "../types.js";
+
+const TEST_PORT = 8794;
+const TEST_API_KEY = "test-key-qb";
+
+describe("hitl-channel WS routing for SPEC-HC-004", () => {
+  let mcpMock: Server;
+  let server: ReturnType<typeof startHttpBridge>;
+
+  beforeAll(() => {
+    process.env.HITL_CHANNEL_PORT = TEST_PORT.toString();
+    process.env.HITL_CHANNEL_API_KEY = TEST_API_KEY;
+    process.env.HITL_INSTANCE_ID = "instance-test-ws";
+    mcpMock = { notification: async () => {} } as unknown as Server;
+    server = startHttpBridge(mcpMock);
+  });
+
+  afterAll(() => {
+    server.stop(true);
+  });
+
+  async function openWS(): Promise<WebSocket> {
+    const ws = new WebSocket(
+      `ws://127.0.0.1:${TEST_PORT}/ws?api_key=${TEST_API_KEY}`,
+    );
+    await new Promise<void>((resolve, reject) => {
+      ws.onopen = () => resolve();
+      ws.onerror = (e) => reject(e);
+    });
+    return ws;
+  }
+
+  it("AV8: well-formed questions_batch_result resolves the waiter", async () => {
+    const ws = await openWS();
+    try {
+      const requestId = `req-${Date.now()}`;
+      const waiter = correlator.register<QuestionsBatchResultFrame>(
+        requestId,
+        5_000,
+      );
+      const frame: QuestionsBatchResultFrame = {
+        type: "questions_batch_result",
+        request_id: requestId,
+        answers: [{ header: "Mode", selected: ["A"] }],
+        cancelled: false,
+      };
+      ws.send(JSON.stringify(frame));
+      const result = await waiter;
+      expect(result.type).toBe("questions_batch_result");
+      expect(result.answers[0]!.selected).toEqual(["A"]);
+      expect(correlator.size).toBe(0);
+    } finally {
+      ws.close();
+    }
+  });
+
+  it("AV8: malformed questions_batch_result (missing answers) is dropped, waiter not resolved", async () => {
+    const ws = await openWS();
+    try {
+      const requestId = `req-bad-${Date.now()}`;
+      const waiter = correlator.register<QuestionsBatchResultFrame>(
+        requestId,
+        200,
+      );
+      ws.send(
+        JSON.stringify({
+          type: "questions_batch_result",
+          request_id: requestId,
+          // answers intentionally missing
+          cancelled: false,
+        }),
+      );
+      // Give the WS handler a moment to process; the waiter must NOT resolve.
+      await new Promise((r) => setTimeout(r, 50));
+      expect(correlator.size).toBe(1);
+      // Eventually timeout fires (~200ms after register) — confirm it rejects.
+      await expect(waiter).rejects.toThrow(/timeout/);
+    } finally {
+      ws.close();
+    }
+  });
+
+  it("AV4 (deviation): with no WS client connected, present_questions_to_hitl handler short-circuits with isError — frame is NOT buffered (matches call_phone_tool semantics; ReplyBuffer accepts ReplyPayload only)", async () => {
+    // No WS client opened in this test — relies on handler-level guard.
+    // This documents the deviation from the spec's AV4 wording.
+    const { presentQuestionsToHitl } = await import("../questions_batch.js");
+    const { FrameCorrelator } = await import("../correlator.js");
+    const result = await presentQuestionsToHitl(
+      { questions: [{ header: "Mode", question: "Q", choices: ["A", "B"] }] },
+      {
+        correlator: new FrameCorrelator(),
+        broadcastFrame: () => 0,
+        clientsSize: () => 0,
+        instanceId: "test",
+        generateRequestId: () => "id",
+      },
+    );
+    expect(result.isError).toBe(true);
+  });
+});

--- a/src/__tests__/questions_batch_ws.test.ts
+++ b/src/__tests__/questions_batch_ws.test.ts
@@ -83,6 +83,54 @@ describe("hitl-channel WS routing for SPEC-HC-004", () => {
     }
   });
 
+  it("AV8: questions_batch_result with missing `cancelled` is dropped, waiter not resolved", async () => {
+    const ws = await openWS();
+    try {
+      const requestId = `req-no-cancel-${Date.now()}`;
+      const waiter = correlator.register<QuestionsBatchResultFrame>(
+        requestId,
+        200,
+      );
+      ws.send(
+        JSON.stringify({
+          type: "questions_batch_result",
+          request_id: requestId,
+          answers: [{ header: "X", selected: ["A"] }],
+          // cancelled intentionally omitted
+        }),
+      );
+      await new Promise((r) => setTimeout(r, 50));
+      expect(correlator.size).toBe(1);
+      await expect(waiter).rejects.toThrow(/timeout/);
+    } finally {
+      ws.close();
+    }
+  });
+
+  it("AV8: questions_batch_result with non-boolean `cancelled` is dropped", async () => {
+    const ws = await openWS();
+    try {
+      const requestId = `req-bad-cancel-${Date.now()}`;
+      const waiter = correlator.register<QuestionsBatchResultFrame>(
+        requestId,
+        200,
+      );
+      ws.send(
+        JSON.stringify({
+          type: "questions_batch_result",
+          request_id: requestId,
+          answers: [],
+          cancelled: "no", // wrong type
+        }),
+      );
+      await new Promise((r) => setTimeout(r, 50));
+      expect(correlator.size).toBe(1);
+      await expect(waiter).rejects.toThrow(/timeout/);
+    } finally {
+      ws.close();
+    }
+  });
+
   it("AV4 (deviation): with no WS client connected, present_questions_to_hitl handler short-circuits with isError — frame is NOT buffered (matches call_phone_tool semantics; ReplyBuffer accepts ReplyPayload only)", async () => {
     // No WS client opened in this test — relies on handler-level guard.
     // This documents the deviation from the spec's AV4 wording.

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -28,7 +28,8 @@ export type AuditKind =
   | "reply"
   | "choices"
   | "tool_call"
-  | "tool_result";
+  | "tool_result"
+  | "questions_batch";
 
 export type AuditApproval =
   | "auto"

--- a/src/http_bridge.ts
+++ b/src/http_bridge.ts
@@ -435,11 +435,27 @@ export function startHttpBridge(mcp: Server) {
           // request_id is logged at warn level and dropped (no waiter, no
           // audit double-count) per the idempotency contract.
           const frameType = typeof data.type === "string" ? data.type : undefined;
-          if (frameType === "tool_call_result" || frameType === "list_tools_result") {
+          if (
+            frameType === "tool_call_result" ||
+            frameType === "list_tools_result" ||
+            frameType === "questions_batch_result"
+          ) {
             const reqId = typeof data.request_id === "string" ? data.request_id : undefined;
             if (!reqId) {
               process.stderr.write(
                 `[hitl-channel] WARN ${frameType} missing request_id — dropped\n`
+              );
+              return;
+            }
+            // SPEC-HC-004 — `questions_batch_result` payload validation: drop
+            // frames missing the `answers` array. Keeps the closed-schema
+            // contract symmetric with the missing-request_id branch above.
+            if (
+              frameType === "questions_batch_result" &&
+              !Array.isArray((data as { answers?: unknown }).answers)
+            ) {
+              process.stderr.write(
+                `[hitl-channel] WARN questions_batch_result missing answers — dropped\n`
               );
               return;
             }
@@ -448,6 +464,27 @@ export function startHttpBridge(mcp: Server) {
               process.stderr.write(
                 `[hitl-channel] WARN ${frameType} for unknown request_id ${reqId} — dropped\n`
               );
+              return;
+            }
+            if (frameType === "questions_batch_result") {
+              // SPEC-HC-004 — closed-schema audit emission for the return path.
+              // prompt_hash is computed over `answers` so the dispatch row's
+              // hash (over `questions`) and the result row's hash differ for
+              // the same logical event.
+              void appendAudit({
+                ts: new Date().toISOString(),
+                instance_id: process.env.HITL_INSTANCE_ID ?? "unknown",
+                direction: "phone_returns_to_cc",
+                kind: "questions_batch",
+                tool_name: null,
+                approval: null,
+                prompt_hash: sha256Hex(
+                  JSON.stringify((data as { answers?: unknown }).answers ?? null)
+                ),
+                duration_ms: null,
+                attachment_count: 0,
+                attachment_bytes: 0,
+              });
               return;
             }
             // SPEC-HITL-CC-001 Phase 6 carry-forward (issue #12) — extract

--- a/src/http_bridge.ts
+++ b/src/http_bridge.ts
@@ -450,14 +450,19 @@ export function startHttpBridge(mcp: Server) {
             // SPEC-HC-004 — `questions_batch_result` payload validation: drop
             // frames missing the `answers` array. Keeps the closed-schema
             // contract symmetric with the missing-request_id branch above.
-            if (
-              frameType === "questions_batch_result" &&
-              !Array.isArray((data as { answers?: unknown }).answers)
-            ) {
-              process.stderr.write(
-                `[hitl-channel] WARN questions_batch_result missing answers — dropped\n`
-              );
-              return;
+            if (frameType === "questions_batch_result") {
+              if (!Array.isArray((data as { answers?: unknown }).answers)) {
+                process.stderr.write(
+                  `[hitl-channel] WARN questions_batch_result missing answers — dropped\n`
+                );
+                return;
+              }
+              if (typeof (data as { cancelled?: unknown }).cancelled !== "boolean") {
+                process.stderr.write(
+                  `[hitl-channel] WARN questions_batch_result missing/non-boolean cancelled — dropped\n`
+                );
+                return;
+              }
             }
             const resolved = correlator.resolve(reqId, data);
             if (!resolved) {

--- a/src/questions_batch.ts
+++ b/src/questions_batch.ts
@@ -1,0 +1,288 @@
+/**
+ * SPEC-HC-004 — `present_questions_to_hitl` MCP tool handler.
+ *
+ * Strict structural sibling of `call_phone_tool` (SPEC-HITL-CC-001 Phase 1):
+ * generate UUID, register correlator waiter, broadcast one frame, await result,
+ * emit closed-schema audit rows on dispatch + return path.
+ *
+ * Extracted from server.ts so the validation + dispatch logic is unit-testable
+ * without booting the stdio MCP transport (server.ts has a top-level
+ * `await mcp.connect(...)`).
+ */
+import { appendAudit, sha256Hex } from "./audit.js";
+import type { FrameCorrelator } from "./correlator.js";
+import type {
+  QuestionSpec,
+  QuestionsBatchRequestFrame,
+  QuestionsBatchResultFrame,
+} from "./types.js";
+
+const MAX_QUESTIONS = 4;
+const MIN_QUESTIONS = 1;
+const MIN_CHOICES = 2;
+const MAX_CHOICES = 4;
+const MAX_HEADER_LEN = 12;
+const MAX_QUESTION_LEN = 1000;
+const DEFAULT_TIMEOUT_S = 300;
+const HARD_CAP_TIMEOUT_S = 900;
+
+export const PRESENT_QUESTIONS_TOOL_DEFINITION = {
+  name: "present_questions_to_hitl",
+  description:
+    "Pose 1–4 related questions to the paired HITL phone user in a single " +
+    "round-trip. Returns one structured `{answers, cancelled}` payload. " +
+    "LAN-path sibling of the cloud relay's `request_human_input_multiple`. " +
+    "Each QuestionSpec has {header (≤12 chars), question (≤1000 chars), " +
+    "choices (2–4 strings), optional multi_select, optional allow_other}.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      questions: {
+        type: "array",
+        minItems: MIN_QUESTIONS,
+        maxItems: MAX_QUESTIONS,
+        items: {
+          type: "object",
+          properties: {
+            header: { type: "string", maxLength: MAX_HEADER_LEN },
+            question: { type: "string", maxLength: MAX_QUESTION_LEN },
+            choices: {
+              type: "array",
+              minItems: MIN_CHOICES,
+              maxItems: MAX_CHOICES,
+              items: { type: "string" },
+            },
+            multi_select: { type: "boolean" },
+            allow_other: { type: "boolean" },
+          },
+          required: ["header", "question", "choices"],
+        },
+      },
+      timeout_seconds: {
+        type: "number",
+        description: `Round-trip timeout. Default ${DEFAULT_TIMEOUT_S}, hard cap ${HARD_CAP_TIMEOUT_S}.`,
+      },
+    },
+    required: ["questions"],
+  },
+} as const;
+
+export type ValidationResult =
+  | { ok: true; questions: QuestionSpec[]; timeoutSeconds: number }
+  | { ok: false; error: string };
+
+/**
+ * Validate raw MCP arguments into a normalised QuestionSpec[]. MCP SDK schema
+ * validation alone is not relied upon — we enforce the constraints here so a
+ * malformed call is rejected with a clear error and never produces a WS frame.
+ */
+export function validateQuestionsArgs(
+  args: Record<string, unknown>,
+): ValidationResult {
+  const rawQuestions = args.questions;
+  if (!Array.isArray(rawQuestions)) {
+    return { ok: false, error: "`questions` must be an array" };
+  }
+  if (rawQuestions.length < MIN_QUESTIONS) {
+    return {
+      ok: false,
+      error: `\`questions\` must have at least ${MIN_QUESTIONS} entry`,
+    };
+  }
+  if (rawQuestions.length > MAX_QUESTIONS) {
+    return {
+      ok: false,
+      error: `\`questions\` exceeds max length ${MAX_QUESTIONS}`,
+    };
+  }
+  const questions: QuestionSpec[] = [];
+  for (let i = 0; i < rawQuestions.length; i++) {
+    const q = rawQuestions[i];
+    if (!q || typeof q !== "object") {
+      return { ok: false, error: `questions[${i}] must be an object` };
+    }
+    const obj = q as Record<string, unknown>;
+    const header = obj.header;
+    const question = obj.question;
+    const choices = obj.choices;
+    if (typeof header !== "string" || header.length === 0) {
+      return {
+        ok: false,
+        error: `questions[${i}].header must be a non-empty string`,
+      };
+    }
+    if (header.length > MAX_HEADER_LEN) {
+      return {
+        ok: false,
+        error: `questions[${i}].header exceeds max length ${MAX_HEADER_LEN}`,
+      };
+    }
+    if (typeof question !== "string" || question.length === 0) {
+      return {
+        ok: false,
+        error: `questions[${i}].question must be a non-empty string`,
+      };
+    }
+    if (question.length > MAX_QUESTION_LEN) {
+      return {
+        ok: false,
+        error: `questions[${i}].question exceeds max length ${MAX_QUESTION_LEN}`,
+      };
+    }
+    if (!Array.isArray(choices)) {
+      return { ok: false, error: `questions[${i}].choices must be an array` };
+    }
+    if (choices.length < MIN_CHOICES) {
+      return {
+        ok: false,
+        error: `questions[${i}].choices must have at least ${MIN_CHOICES} entries`,
+      };
+    }
+    if (choices.length > MAX_CHOICES) {
+      return {
+        ok: false,
+        error: `questions[${i}].choices exceeds max length ${MAX_CHOICES}`,
+      };
+    }
+    for (let j = 0; j < choices.length; j++) {
+      if (typeof choices[j] !== "string") {
+        return {
+          ok: false,
+          error: `questions[${i}].choices[${j}] must be a string`,
+        };
+      }
+    }
+    const spec: QuestionSpec = {
+      header,
+      question,
+      choices: choices as string[],
+    };
+    if (typeof obj.multi_select === "boolean") {
+      spec.multi_select = obj.multi_select;
+    }
+    if (typeof obj.allow_other === "boolean") {
+      // Phase 2 deferred: kept in the type definition so mobile can light it
+      // up unilaterally. No MV-time semantics on the channel side.
+      spec.allow_other = obj.allow_other;
+    }
+    questions.push(spec);
+  }
+  const rawTimeout = Number(args.timeout_seconds ?? DEFAULT_TIMEOUT_S);
+  const timeoutSeconds = Math.min(
+    HARD_CAP_TIMEOUT_S,
+    Math.max(1, Number.isFinite(rawTimeout) ? rawTimeout : DEFAULT_TIMEOUT_S),
+  );
+  return { ok: true, questions, timeoutSeconds };
+}
+
+export interface PresentQuestionsDeps {
+  correlator: FrameCorrelator;
+  broadcastFrame: (frame: Record<string, unknown>) => number;
+  clientsSize: () => number;
+  instanceId: string;
+  generateRequestId: () => string;
+  /** Test seam — overridden in unit tests to avoid touching the audit file. */
+  audit?: typeof appendAudit;
+  /** Test seam — overridden in unit tests to control `ts` deterministically. */
+  now?: () => Date;
+}
+
+export interface PresentQuestionsResult {
+  isError?: boolean;
+  content: Array<{ type: "text"; text: string }>;
+  [key: string]: unknown;
+}
+
+export async function presentQuestionsToHitl(
+  args: Record<string, unknown>,
+  deps: PresentQuestionsDeps,
+): Promise<PresentQuestionsResult> {
+  const audit = deps.audit ?? appendAudit;
+  const now = deps.now ?? (() => new Date());
+
+  if (deps.clientsSize() === 0) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text" as const,
+          text: "No paired HITL phone is currently connected.",
+        },
+      ],
+    };
+  }
+
+  const v = validateQuestionsArgs(args);
+  if (!v.ok) {
+    return {
+      isError: true,
+      content: [{ type: "text", text: v.error }],
+    };
+  }
+
+  const requestId = deps.generateRequestId();
+  const ts = now().toISOString();
+  const frame: QuestionsBatchRequestFrame = {
+    type: "questions_batch_request",
+    request_id: requestId,
+    questions: v.questions,
+    ts,
+  };
+
+  void audit({
+    ts,
+    instance_id: deps.instanceId,
+    direction: "cc_to_phone",
+    kind: "questions_batch",
+    tool_name: null,
+    approval: null,
+    prompt_hash: sha256Hex(JSON.stringify(v.questions)),
+    duration_ms: null,
+    attachment_count: 0,
+    attachment_bytes: 0,
+  });
+
+  const waiter = deps.correlator.register<QuestionsBatchResultFrame>(
+    requestId,
+    v.timeoutSeconds * 1000,
+  );
+  const delivered = deps.broadcastFrame(
+    frame as unknown as Record<string, unknown>,
+  );
+  if (delivered === 0) {
+    deps.correlator.reject(
+      requestId,
+      new Error("no_phone_connected_post_check"),
+    );
+  }
+
+  try {
+    const result = await waiter;
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              answers: result.answers ?? [],
+              cancelled: Boolean(result.cancelled),
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text" as const,
+          text: `present_questions_to_hitl failed: ${msg}`,
+        },
+      ],
+    };
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,6 +29,10 @@ import type {
   ListToolsResultFrame,
   ToolCallResultFrame,
 } from "./types.js";
+import {
+  PRESENT_QUESTIONS_TOOL_DEFINITION,
+  presentQuestionsToHitl,
+} from "./questions_batch.js";
 
 const PORT = Number(process.env.HITL_CHANNEL_PORT ?? 8789);
 
@@ -193,6 +197,8 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ["name"],
       },
     },
+    // ─── SPEC-HC-004 ─────────────────────────────────────────────────────
+    PRESENT_QUESTIONS_TOOL_DEFINITION,
   ],
 }));
 
@@ -628,6 +634,16 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
         ],
       };
     }
+  }
+
+  if (req.params.name === "present_questions_to_hitl") {
+    return presentQuestionsToHitl(args, {
+      correlator,
+      broadcastFrame,
+      clientsSize: () => clients.size,
+      instanceId: identity.instanceId,
+      generateRequestId,
+    });
   }
 
   throw new Error(`Unknown tool: ${req.params.name}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,6 +85,39 @@ export interface BootstrapFrame {
   meta: { type: "bootstrap" };
 }
 
+// ─── SPEC-HC-004 — Batched-question frame types ───────────────────────────
+// Mirror of the relay-side SPEC-AW-311 shapes so a payload captured on either
+// transport is structurally identical. `allow_other` is accepted in the type
+// definition but has no MV-time semantics on the channel side (Phase 2 deferred).
+
+export interface QuestionSpec {
+  header: string;
+  question: string;
+  choices: string[];
+  multi_select?: boolean;
+  allow_other?: boolean;
+}
+
+export interface QuestionAnswer {
+  header: string;
+  selected: string[];
+  other_text?: string;
+}
+
+export interface QuestionsBatchRequestFrame {
+  type: "questions_batch_request";
+  request_id: string;
+  questions: QuestionSpec[];
+  ts: string;
+}
+
+export interface QuestionsBatchResultFrame {
+  type: "questions_batch_result";
+  request_id: string;
+  answers: QuestionAnswer[];
+  cancelled: boolean;
+}
+
 // ─── SPEC-HITL-CC-001 Phase 4 AC#26 — ReplyBuffer types ───────────────────
 // Per-instance in-memory ring buffer for replies that arrive while no WS
 // clients are connected. Entries drain in arrival order on WS reconnect.


### PR DESCRIPTION
## Summary

Implements **SPEC-HC-004**: LAN-side wire for batched human-input.

- New MCP tool `present_questions_to_hitl` — 1–4 `QuestionSpec` per call → one `{answers, cancelled}` payload via the existing `FrameCorrelator` (no new transport machinery).
- New WS frame pair `questions_batch_request` / `questions_batch_result` added to `src/types.ts`; result-frame routing extends the existing `tool_call_result` / `list_tools_result` discriminator branch in `src/http_bridge.ts` (type-first routing preserved).
- `AuditKind` enum extended with one new value `"questions_batch"` used for both dispatch (`cc_to_phone`, prompt_hash over `questions`) and result (`phone_returns_to_cc`, prompt_hash over `answers`) rows.
- Handler logic extracted into `src/questions_batch.ts` so unit tests can exercise validation + dispatch without booting `server.ts`'s top-level `await mcp.connect(...)`. Mirrors the call_phone_tool shape inline in server.ts.

Spec: `.specs/features/SPEC-HC-004_questions_batch_frames.md` (already on `main`).

## Acceptance Criteria

### Agent-verifiable (CI) — all PASS

- **AV1** — `validateQuestionsArgs` rejects `< 1`, `> 4` questions; `< 2`, `> 4` choices; `> 12 char` header. 5 dedicated cases in `questions_batch.test.ts` validation suite, plus a schema-shape assertion in `PRESENT_QUESTIONS_TOOL_DEFINITION` test.
- **AV2** — happy-path dispatch emits exactly one frame, registers exactly one waiter, resolves on mock result; payload shape `{answers, cancelled}` round-trips intact. ✅
- **AV3** — closed-schema audit rows on both directions; `tool_name: null`, `attachment_count: 0`, `attachment_bytes: 0`; prompt_hash differs between dispatch (`questions`) and result (`answers`). ✅
- **AV4** — ⚠️ **deviation from spec wording.** The spec claims `questions_batch_request` frames are auto-buffered by the existing `ReplyBuffer` when no client is connected. In code, `ReplyBuffer.push()` only accepts `ReplyPayload`, and `broadcastFrame` does NOT route through it — so the literal AV4 behaviour is not achievable without extending `ReplyBuffer`, which §4.2 of the spec explicitly forbids (\"reused as-is\"). Implementation matches `call_phone_tool`: when `clients.size === 0`, the handler short-circuits with `isError: true` (\"No paired HITL phone is currently connected.\"). Documented in `questions_batch_ws.test.ts` AV4 test.
- **AV5** — full local suite: 88 pass / 3 fail / 2 errors. The 3 failures + 2 errors are pre-existing on `origin/main` (`pairing-integration.test.ts` port conflict between two parallel `startHttpBridge` invocations at port 8791). Verified via `git worktree add /tmp/main-check origin/main && bun test` → same 71 pass / 3 fail / 2 errors. Net: +17 new tests, all passing, zero regression.
- **AV6** — timeout: `timeout_seconds: 0.01` with no reply rejects via the existing correlator timeout machinery; correlator empty after rejection. ✅
- **AV7** — `correlator.rejectAll(new Error('phone_disconnected'))` mid-flight surfaces `phone_disconnected` to the MCP caller. ✅
- **AV8** — routing branch: well-formed `questions_batch_result` resolves the waiter; missing-`answers` payload is logged at warn level and dropped (waiter survives until its own timeout). ✅

### CEO / external-verify

- **CV1, CV2, CV3** — `STATUS: UNVERIFIED — work-with-CEO`. Require paired iPhone + matching SPEC-HITL-APP-4116 client to round-trip on device.

## Test plan

- [x] `bun test src/__tests__/questions_batch.test.ts` — 13 cases (validation + handler) all pass.
- [x] `bun test src/__tests__/questions_batch_ws.test.ts` — 3 cases (WS routing + AV4 deviation doc) all pass.
- [x] `bun test src/__tests__/audit.test.ts` — extended with `questions_batch` kind acceptance.
- [x] `bunx tsc --noEmit` — clean.
- [x] Full suite: 88 pass / 3 fail / 2 errors (pre-existing on main, unchanged).
- [ ] **CV1–CV3** on-device with paired iPhone (work-with-CEO).

Refs #16