### PR TITLE
fix(SPEC-AW-311): make present_questions_to_hitl fire-and-forget

### DIFF
--- a/src/__tests__/questions_batch.test.ts
+++ b/src/__tests__/questions_batch.test.ts
@@ -6,10 +6,7 @@ import {
   validateQuestionsArgs,
 } from "../questions_batch.js";
 import type { AuditEvent } from "../audit.js";
-import type {
-  QuestionsBatchRequestFrame,
-  QuestionsBatchResultFrame,
-} from "../types.js";
+import type { QuestionsBatchRequestFrame } from "../types.js";
 
 const validQuestion = () => ({
   header: "Mode",
@@ -128,40 +125,30 @@ describe("PRESENT_QUESTIONS_TOOL_DEFINITION", () => {
   });
 });
 
-describe("presentQuestionsToHitl handler (AV2/AV3/AV6/AV7)", () => {
-  it("happy-path: dispatches one frame, registers waiter, resolves on result", async () => {
+describe("presentQuestionsToHitl handler (SPEC-AW-311 fire-and-forget)", () => {
+  it("happy-path: dispatches one frame, returns immediately, registers no waiter", async () => {
     const { correlator, emittedFrames, auditRows, deps } = makeHandlerDeps();
-    const handlerPromise = presentQuestionsToHitl(
+
+    const result = await presentQuestionsToHitl(
       { questions: [validQuestion()] },
       deps,
     );
 
-    // Exactly one frame should have been emitted before we await.
-    await Promise.resolve(); // let the synchronous part of the handler run
+    // Fire-and-forget: handler returns before any phone reply.
     expect(emittedFrames.length).toBe(1);
     const frame = emittedFrames[0] as unknown as QuestionsBatchRequestFrame;
     expect(frame.type).toBe("questions_batch_request");
     expect(frame.request_id).toBe("req-fixed-uuid");
     expect(frame.questions.length).toBe(1);
-    expect(correlator.size).toBe(1);
-
-    // Simulate the phone replying.
-    const reply: QuestionsBatchResultFrame = {
-      type: "questions_batch_result",
-      request_id: frame.request_id,
-      answers: [{ header: "Mode", selected: ["A"] }],
-      cancelled: false,
-    };
-    correlator.resolve(frame.request_id, reply);
-
-    const result = await handlerPromise;
-    expect(result.isError).toBeUndefined();
-    const payload = JSON.parse(result.content[0]!.text);
-    expect(payload.cancelled).toBe(false);
-    expect(payload.answers).toEqual([{ header: "Mode", selected: ["A"] }]);
+    // No correlator waiter is registered — answers flow back as a normal
+    // channel notification rather than via a synchronous round-trip.
     expect(correlator.size).toBe(0);
 
-    // AV3 dispatch-side audit row exists with the right shape.
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toMatch(/Survey presented/);
+    expect(result.content[0]!.text).toMatch(/req-fixed-uuid/);
+
+    // Dispatch-side audit row still emits with the closed-schema shape.
     expect(auditRows.length).toBe(1);
     expect(auditRows[0]!.direction).toBe("cc_to_phone");
     expect(auditRows[0]!.kind).toBe("questions_batch");
@@ -171,28 +158,21 @@ describe("presentQuestionsToHitl handler (AV2/AV3/AV6/AV7)", () => {
     expect(auditRows[0]!.prompt_hash.length).toBe(64);
   });
 
-  it("AV6: timeout rejects waiter and surfaces error to MCP caller", async () => {
-    const { correlator, deps } = makeHandlerDeps();
+  it("returns no_phone_connected error when broadcastFrame delivers to zero clients", async () => {
+    const { correlator, emittedFrames, deps } = makeHandlerDeps();
+    // Override broadcastFrame to simulate zero delivery (phone disconnected
+    // after the clientsSize() pre-check).
+    deps.broadcastFrame = (frame) => {
+      emittedFrames.push(frame);
+      return 0;
+    };
     const result = await presentQuestionsToHitl(
-      { questions: [validQuestion()], timeout_seconds: 0.01 },
-      deps,
-    );
-    expect(result.isError).toBe(true);
-    expect(result.content[0]!.text).toMatch(/timeout/);
-    expect(correlator.size).toBe(0);
-  });
-
-  it("AV7: connection drop (rejectAll) surfaces to MCP caller", async () => {
-    const { correlator, deps } = makeHandlerDeps();
-    const handlerPromise = presentQuestionsToHitl(
       { questions: [validQuestion()] },
       deps,
     );
-    await Promise.resolve();
-    correlator.rejectAll(new Error("phone_disconnected"));
-    const result = await handlerPromise;
     expect(result.isError).toBe(true);
-    expect(result.content[0]!.text).toMatch(/phone_disconnected/);
+    expect(result.content[0]!.text).toMatch(/no_phone_connected/);
+    expect(correlator.size).toBe(0);
   });
 
   it("returns an error and skips dispatch when no phone is connected", async () => {

--- a/src/questions_batch.ts
+++ b/src/questions_batch.ts
@@ -1,9 +1,18 @@
 /**
  * SPEC-HC-004 — `present_questions_to_hitl` MCP tool handler.
  *
- * Strict structural sibling of `call_phone_tool` (SPEC-HITL-CC-001 Phase 1):
- * generate UUID, register correlator waiter, broadcast one frame, await result,
- * emit closed-schema audit rows on dispatch + return path.
+ * Fire-and-forget dispatch sibling of `present_choices_to_hitl`
+ * (server.ts:383). Generate UUID, emit closed-schema dispatch audit row,
+ * broadcast one WS frame to the phone, return immediately. The user's
+ * submitted answers arrive on a later agent turn as a normal channel
+ * notification carrying the same `request_id` — callers can correlate
+ * by that id if they care.
+ *
+ * Previous design (SPEC-AW-311 v1) registered a correlator waiter and
+ * blocked the MCP call until the phone returned a `questions_batch_result`
+ * WS frame. That path doesn't work in practice: the phone-side response
+ * goes via HTTP POST to `/` (notification surface), never reaches the
+ * correlator, so the waiter sat blocked until `timeout_seconds` elapsed.
  *
  * Extracted from server.ts so the validation + dispatch logic is unit-testable
  * without booting the stdio MCP transport (server.ts has a top-level
@@ -14,7 +23,6 @@ import type { FrameCorrelator } from "./correlator.js";
 import type {
   QuestionSpec,
   QuestionsBatchRequestFrame,
-  QuestionsBatchResultFrame,
 } from "./types.js";
 
 const MAX_QUESTIONS = 4;
@@ -242,47 +250,44 @@ export async function presentQuestionsToHitl(
     attachment_bytes: 0,
   });
 
-  const waiter = deps.correlator.register<QuestionsBatchResultFrame>(
-    requestId,
-    v.timeoutSeconds * 1000,
-  );
+  // SPEC-AW-311 — fire-and-forget dispatch (matches `present_choices_to_hitl`
+  // in server.ts:383). The previous synchronous `correlator.register + await
+  // waiter` pattern blocked the agent's MCP call for the full
+  // `timeout_seconds` window (up to 15 min) because the phone-side response
+  // never reaches the correlator: `claudeCodeService.sendMessage` POSTs to
+  // `/` (notification path) and only inbound WS frames trigger
+  // `correlator.resolve`. Returning immediately matches how every other
+  // channel tool behaves; the user's submitted answers surface as a normal
+  // channel notification on the next agent turn (carries the same
+  // `request_id` so callers can correlate if they care).
   const delivered = deps.broadcastFrame(
     frame as unknown as Record<string, unknown>,
   );
   if (delivered === 0) {
-    deps.correlator.reject(
-      requestId,
-      new Error("no_phone_connected_post_check"),
-    );
-  }
-
-  try {
-    const result = await waiter;
-    return {
-      content: [
-        {
-          type: "text" as const,
-          text: JSON.stringify(
-            {
-              answers: result.answers ?? [],
-              cancelled: Boolean(result.cancelled),
-            },
-            null,
-            2,
-          ),
-        },
-      ],
-    };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
     return {
       isError: true,
       content: [
         {
           type: "text" as const,
-          text: `present_questions_to_hitl failed: ${msg}`,
+          text: `present_questions_to_hitl failed: no_phone_connected_post_check (request_id=${requestId})`,
         },
       ],
     };
   }
+  // `v.timeoutSeconds` is preserved on the wire frame above for the phone
+  // renderer's optional UI gate; the channel no longer enforces it server-
+  // side because there's no waiter to time out.
+  void v.timeoutSeconds;
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text:
+          `Survey presented to user (${v.questions.length} question${v.questions.length === 1 ? "" : "s"}, ` +
+          `request_id=${requestId}). Answers will arrive as a separate ` +
+          `channel notification with the same request_id.`,
+      },
+    ],
+  };
 }


### PR DESCRIPTION
## Summary

Drops the `correlator.register + await waiter` blocking pattern from `present_questions_to_hitl` and returns immediately with the `request_id`. Matches the long-standing `present_choices_to_hitl` shape in `server.ts:383`.

**Why:** the previous design assumed the phone would reply via an inbound WS `questions_batch_result` frame that the correlator could resolve. In practice the phone sends responses via HTTP POST to `/`, which the channel routes through `sendChannelNotification` — it never reaches the correlator. Result: the MCP call sat blocked for the full `timeout_seconds` window (up to 15 min) even when the user submitted answers on the phone. CEO had to manually cancel.

After this fix, the agent dispatches the survey, gets back a status string with the `request_id`, and the user's answers arrive on a later turn as a normal channel notification carrying the same `request_id`.

## Test plan

- [x] `bun test src/__tests__/questions_batch.test.ts` — 12/12 green
- [x] Full suite `bun test` — 92/92 green
- [ ] On-device CV: fire `present_questions_to_hitl`, agent returns immediately, user answers + submits, answers surface as inbound channel message — `STATUS: UNVERIFIED — work-with-CEO`

## Wire-contract change note

The MCP tool's return value changes from `JSON.stringify({answers, cancelled})` to a short status string with the `request_id`. Callers that consumed the structured payload as a sync return must now correlate via the inbound channel notification. Reflected in the test suite + the docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)