### PR TITLE
fix: format questions_batch survey answers into notification content

### DIFF
--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -78,11 +78,48 @@ describe("hitl-channel HTTP Bridge", () => {
 
     expect(response.status).toBe(200);
     expect(lastNotification).not.toBeNull();
-    expect(lastNotification.params.content).toBe("Submitted 3 answers");
+    expect(lastNotification.params.content).toBe("Submitted 3 answers — H1: [A]");
     expect(lastNotification.params.meta.type).toBe("questions_batch_response");
     expect(lastNotification.params.meta.batch_id).toBe("req-123");
     // Verify batch_id -> request_id mapping
     expect(lastNotification.params.meta.request_id).toBe("req-123");
+    expect(JSON.parse(lastNotification.params.meta.batch_answer)).toEqual(payload.metadata.batch_answer);
+  });
+
+  it("POST / should handle multi-answer and cancelled rendering for questions_batch_response", async () => {
+    lastNotification = null;
+    const payload = {
+      message: "Submitted 2 answers",
+      metadata: {
+        type: "questions_batch_response",
+        batch_id: "req-456",
+        batch_answer: {
+          answers: [
+            { header: "Horizon", selected: ["Both"] },
+            { header: "Primary win", selected: ["Agents+Automations", "Required-vars"] }
+          ],
+          cancelled: true
+        }
+      }
+    };
+
+    const response = await fetch(`http://127.0.0.1:${TEST_PORT}/`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${TEST_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    expect(response.status).toBe(200);
+    expect(lastNotification).not.toBeNull();
+    expect(lastNotification.params.content).toBe(
+      "Submitted 2 answers (cancelled) — Horizon: [Both]; Primary win: [Agents+Automations, Required-vars]"
+    );
+    expect(lastNotification.params.meta.type).toBe("questions_batch_response");
+    expect(lastNotification.params.meta.batch_id).toBe("req-456");
+    expect(lastNotification.params.meta.request_id).toBe("req-456");
     expect(JSON.parse(lastNotification.params.meta.batch_answer)).toEqual(payload.metadata.batch_answer);
   });
 

--- a/src/http_bridge.ts
+++ b/src/http_bridge.ts
@@ -375,7 +375,7 @@ export function startHttpBridge(mcp: Server) {
               );
             }
 
-            const contentForNotification = await processAttachments(
+            let contentForNotification = await processAttachments(
               message,
               attachments
             );
@@ -384,6 +384,39 @@ export function startHttpBridge(mcp: Server) {
             const extraMeta = { ...metadata };
             if (extraMeta.batch_id && !extraMeta.request_id) {
               extraMeta.request_id = extraMeta.batch_id;
+            }
+
+            if (metadata?.type === "questions_batch_response") {
+              const batchAnswer = metadata.batch_answer;
+              const isCancelled = batchAnswer?.cancelled === true || metadata.cancelled === true;
+              const answers = batchAnswer?.answers;
+
+              let parts: string[] = [];
+              if (Array.isArray(answers) && answers.length > 0) {
+                const answersStr = answers
+                  .map((ans: any) => {
+                    const header = ans?.header ?? "";
+                    const selected = Array.isArray(ans?.selected)
+                      ? ans.selected.join(", ")
+                      : "";
+                    return `${header}: [${selected}]`;
+                  })
+                  .join("; ");
+                if (answersStr) {
+                  parts.push(answersStr);
+                }
+              }
+
+              let suffix = "";
+              if (isCancelled) {
+                suffix = " (cancelled)";
+              }
+
+              if (parts.length > 0) {
+                contentForNotification = `${contentForNotification}${suffix} — ${parts.join("; ")}`;
+              } else if (suffix) {
+                contentForNotification = `${contentForNotification}${suffix}`;
+              }
             }
 
             await sendChannelNotification(mcp, contentForNotification, {


### PR DESCRIPTION
Closes #21

This PR formats the multi-question survey (questions_batch) answers into the notification content forwarded to the agent, so that it receives the actual selected answers rather than just a generic 'Submitted N answers' summary. Also handles rendering when the survey is cancelled.