### PR TITLE
feat: push_file console-to-phone text file transfer

### DIFF
--- a/src/__tests__/push_file.test.ts
+++ b/src/__tests__/push_file.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it, beforeAll, afterAll } from "bun:test";
+import { mcp } from "../server.js";
+import { clients, correlator } from "../http_bridge.js";
+import { writeFileSync, unlinkSync, mkdirSync, symlinkSync, rmSync, existsSync } from "node:fs";
+import { join, resolve as resolvePath } from "node:path";
+
+describe("push_file MCP Tool", () => {
+  const originalEnv = process.env.HITL_CHANNEL_ATTACHMENT_ROOTS;
+
+  beforeAll(() => {
+    // Set a custom attachment roots for testing
+    process.env.HITL_CHANNEL_ATTACHMENT_ROOTS = "/tmp";
+  });
+
+  afterAll(() => {
+    if (originalEnv !== undefined) {
+      process.env.HITL_CHANNEL_ATTACHMENT_ROOTS = originalEnv;
+    } else {
+      delete process.env.HITL_CHANNEL_ATTACHMENT_ROOTS;
+    }
+  });
+
+  it("should be registered on the hitl-channel MCP server", async () => {
+    const listHandler = (mcp as any)._requestHandlers.get("tools/list");
+    expect(listHandler).toBeDefined();
+    const result = await listHandler({ method: "tools/list" });
+    const pushFileTool = result.tools.find((t: any) => t.name === "push_file");
+    expect(pushFileTool).toBeDefined();
+    expect(pushFileTool.description).toContain("Push a text file");
+    expect(pushFileTool.inputSchema.properties.local_path).toBeDefined();
+    expect(pushFileTool.inputSchema.properties.dest).toBeDefined();
+  });
+
+  it("should be absent from the phone tool catalog returned by list_phone_tools", async () => {
+    const callHandler = (mcp as any)._requestHandlers.get("tools/call");
+    expect(callHandler).toBeDefined();
+
+    // Mock a WS client to satisfy clients.size === 0 guard
+    const mockWs = {
+      readyState: 1,
+      send: () => true,
+    } as any;
+    clients.add(mockWs);
+
+    try {
+      const requestId = "req-list-tools";
+      // We expect list_phone_tools to send a request and wait for reply
+      const listToolsPromise = callHandler({
+        method: "tools/call",
+        params: {
+          name: "list_phone_tools",
+        },
+      });
+
+      // Resolve the waiter via correlator
+      // First, let's wait a tiny bit for the request to register in correlator
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Get the request ID from the correlator
+      const activeReqIds = Array.from((correlator as any).pending.keys());
+      expect(activeReqIds.length).toBe(1);
+      const activeId = activeReqIds[0] as string;
+
+      correlator.resolve(activeId, {
+        type: "list_tools_result",
+        request_id: activeId,
+        tools: [
+          {
+            name: "write_file",
+            description: "writes a file",
+          },
+        ],
+      });
+
+      const result = await listToolsPromise;
+      const toolsObj = JSON.parse(result.content[0].text);
+      const hasPushFile = toolsObj.tools.some((t: any) => t.name === "push_file");
+      expect(hasPushFile).toBe(false);
+    } finally {
+      clients.delete(mockWs);
+    }
+  });
+
+  it("should reject local_path outside allowlisted roots", async () => {
+    const callHandler = (mcp as any)._requestHandlers.get("tools/call");
+
+    const outsideFile = "/home/slaser79/outside.txt";
+    const result = await callHandler({
+      method: "tools/call",
+      params: {
+        name: "push_file",
+        arguments: {
+          local_path: outsideFile,
+          dest: "documents/test.txt",
+        },
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("path outside allowlist");
+  });
+
+  it("should reject symlink-escaping paths", async () => {
+    const callHandler = (mcp as any)._requestHandlers.get("tools/call");
+
+    // Create a symlink to escape the roots
+    const symlinkPath = "/tmp/hitl-escape-link";
+    if (existsSync(symlinkPath)) unlinkSync(symlinkPath);
+    try {
+      symlinkSync("/etc", symlinkPath);
+
+      const result = await callHandler({
+        method: "tools/call",
+        params: {
+          name: "push_file",
+          arguments: {
+            local_path: join(symlinkPath, "passwd"),
+            dest: "documents/passwd",
+          },
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("path outside allowlist");
+    } finally {
+      if (existsSync(symlinkPath)) unlinkSync(symlinkPath);
+    }
+  });
+
+  it("should succeed with an os.tmpdir() based path and invoke write_file on client for general paths", async () => {
+    const callHandler = (mcp as any)._requestHandlers.get("tools/call");
+
+    const tempFile = "/tmp/hitl-push-test.txt";
+    writeFileSync(tempFile, "hello from push_file test", "utf8");
+
+    let receivedFrame: any = null;
+    const mockWs = {
+      readyState: 1,
+      send: (data: string) => {
+        receivedFrame = JSON.parse(data);
+        return true;
+      },
+    } as any;
+    clients.add(mockWs);
+
+    try {
+      const pushPromise = callHandler({
+        method: "tools/call",
+        params: {
+          name: "push_file",
+          arguments: {
+            local_path: tempFile,
+            dest: "documents/foo.txt",
+            overwrite: true,
+          },
+        },
+      });
+
+      // Wait a tiny bit for the request to register
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(receivedFrame).not.toBeNull();
+      expect(receivedFrame.type).toBe("tool_call_request");
+      expect(receivedFrame.name).toBe("write_file");
+      // Arguments check
+      expect(receivedFrame.arguments.path).toBe("documents/foo.txt");
+      expect(receivedFrame.arguments.content).toBe("hello from push_file test");
+      expect(receivedFrame.arguments.overwrite).toBe(true);
+
+      // Resolve the waiter
+      const activeId = receivedFrame.request_id;
+      correlator.resolve(activeId, {
+        type: "tool_call_result",
+        request_id: activeId,
+        success: true,
+        approval: "user_approved",
+        output: "Successfully wrote file to documents/foo.txt",
+      });
+
+      const result = await pushPromise;
+      expect(result.isError).toBeUndefined();
+      const outputObj = JSON.parse(result.content[0].text);
+      expect(outputObj.success).toBe(true);
+      expect(outputObj.approval).toBe("user_approved");
+    } finally {
+      clients.delete(mockWs);
+      if (existsSync(tempFile)) unlinkSync(tempFile);
+    }
+  });
+
+  it("should invoke write_skill_file on client for skills paths", async () => {
+    const callHandler = (mcp as any)._requestHandlers.get("tools/call");
+
+    const tempFile = "/tmp/hitl-skill-push-test.txt";
+    writeFileSync(tempFile, "my skill script content", "utf8");
+
+    let receivedFrame: any = null;
+    const mockWs = {
+      readyState: 1,
+      send: (data: string) => {
+        receivedFrame = JSON.parse(data);
+        return true;
+      },
+    } as any;
+    clients.add(mockWs);
+
+    try {
+      const pushPromise = callHandler({
+        method: "tools/call",
+        params: {
+          name: "push_file",
+          arguments: {
+            local_path: tempFile,
+            dest: "skills/my-awesome-skill/scripts/main.js",
+            overwrite: false,
+          },
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(receivedFrame).not.toBeNull();
+      expect(receivedFrame.type).toBe("tool_call_request");
+      expect(receivedFrame.name).toBe("write_skill_file");
+      // Arguments check
+      expect(receivedFrame.arguments.skillName).toBe("my-awesome-skill");
+      expect(receivedFrame.arguments.filePath).toBe("scripts/main.js");
+      expect(receivedFrame.arguments.content).toBe("my skill script content");
+      expect(receivedFrame.arguments.overwrite).toBe(false);
+
+      // Resolve the waiter
+      const activeId = receivedFrame.request_id;
+      correlator.resolve(activeId, {
+        type: "tool_call_result",
+        request_id: activeId,
+        success: true,
+        approval: "user_approved",
+        output: "Successfully wrote file",
+      });
+
+      const result = await pushPromise;
+      expect(result.isError).toBeUndefined();
+      const outputObj = JSON.parse(result.content[0].text);
+      expect(outputObj.success).toBe(true);
+    } finally {
+      clients.delete(mockWs);
+      if (existsSync(tempFile)) unlinkSync(tempFile);
+    }
+  });
+});

--- a/src/__tests__/push_file.test.ts
+++ b/src/__tests__/push_file.test.ts
@@ -127,6 +127,45 @@ describe("push_file MCP Tool", () => {
     }
   });
 
+  it("should reject destination paths containing dot (.) or dot-dot (..)", async () => {
+    const callHandler = (mcp as any)._requestHandlers.get("tools/call");
+
+    const tempFile = "/tmp/hitl-dot-dest-test.txt";
+    writeFileSync(tempFile, "hello from push_file dot test", "utf8");
+
+    try {
+      // 1. dot-dot rejection
+      const resDotDot = await callHandler({
+        method: "tools/call",
+        params: {
+          name: "push_file",
+          arguments: {
+            local_path: tempFile,
+            dest: "documents/../foo.txt",
+          },
+        },
+      });
+      expect(resDotDot.isError).toBe(true);
+      expect(resDotDot.content[0].text).toContain("invalid destination path");
+
+      // 2. single-dot rejection
+      const resSingleDot = await callHandler({
+        method: "tools/call",
+        params: {
+          name: "push_file",
+          arguments: {
+            local_path: tempFile,
+            dest: "documents/./foo.txt",
+          },
+        },
+      });
+      expect(resSingleDot.isError).toBe(true);
+      expect(resSingleDot.content[0].text).toContain("invalid destination path");
+    } finally {
+      if (existsSync(tempFile)) unlinkSync(tempFile);
+    }
+  });
+
   it("should succeed with an os.tmpdir() based path and invoke write_file on client for general paths", async () => {
     const callHandler = (mcp as any)._requestHandlers.get("tools/call");
 
@@ -152,6 +191,7 @@ describe("push_file MCP Tool", () => {
             local_path: tempFile,
             dest: "documents/foo.txt",
             overwrite: true,
+            media_type: "text/javascript",
           },
         },
       });
@@ -166,6 +206,8 @@ describe("push_file MCP Tool", () => {
       expect(receivedFrame.arguments.path).toBe("documents/foo.txt");
       expect(receivedFrame.arguments.content).toBe("hello from push_file test");
       expect(receivedFrame.arguments.overwrite).toBe(true);
+      expect(receivedFrame.arguments.media_type).toBe("text/javascript");
+      expect(receivedFrame.arguments.contentType).toBe("text/javascript");
 
       // Resolve the waiter
       const activeId = receivedFrame.request_id;
@@ -213,6 +255,7 @@ describe("push_file MCP Tool", () => {
             local_path: tempFile,
             dest: "skills/my-awesome-skill/scripts/main.js",
             overwrite: false,
+            media_type: "application/javascript",
           },
         },
       });
@@ -225,8 +268,12 @@ describe("push_file MCP Tool", () => {
       // Arguments check
       expect(receivedFrame.arguments.skillName).toBe("my-awesome-skill");
       expect(receivedFrame.arguments.filePath).toBe("scripts/main.js");
+      expect(receivedFrame.arguments.file_path).toBe("scripts/main.js");
+      expect(receivedFrame.arguments.filepath).toBe("scripts/main.js");
       expect(receivedFrame.arguments.content).toBe("my skill script content");
       expect(receivedFrame.arguments.overwrite).toBe(false);
+      expect(receivedFrame.arguments.media_type).toBe("application/javascript");
+      expect(receivedFrame.arguments.contentType).toBe("application/javascript");
 
       // Resolve the waiter
       const activeId = receivedFrame.request_id;

--- a/src/__tests__/push_file.test.ts
+++ b/src/__tests__/push_file.test.ts
@@ -294,4 +294,57 @@ describe("push_file MCP Tool", () => {
       if (existsSync(tempFile)) unlinkSync(tempFile);
     }
   });
+
+  it("should infer media_type from extension if omitted", async () => {
+    const callHandler = (mcp as any)._requestHandlers.get("tools/call");
+
+    const tempFile = "/tmp/hitl-infer-test.json";
+    writeFileSync(tempFile, '{"hello": "world"}', "utf8");
+
+    let receivedFrame: any = null;
+    const mockWs = {
+      readyState: 1,
+      send: (data: string) => {
+        receivedFrame = JSON.parse(data);
+        return true;
+      },
+    } as any;
+    clients.add(mockWs);
+
+    try {
+      const pushPromise = callHandler({
+        method: "tools/call",
+        params: {
+          name: "push_file",
+          arguments: {
+            local_path: tempFile,
+            dest: "documents/foo.json",
+          },
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(receivedFrame).not.toBeNull();
+      expect(receivedFrame.type).toBe("tool_call_request");
+      // Arguments check - should infer application/json
+      expect(receivedFrame.arguments.media_type).toBe("application/json");
+      expect(receivedFrame.arguments.contentType).toBe("application/json");
+
+      // Resolve the waiter
+      const activeId = receivedFrame.request_id;
+      correlator.resolve(activeId, {
+        type: "tool_call_result",
+        request_id: activeId,
+        success: true,
+        approval: "user_approved",
+        output: "Successfully wrote JSON file",
+      });
+
+      await pushPromise;
+    } finally {
+      clients.delete(mockWs);
+      if (existsSync(tempFile)) unlinkSync(tempFile);
+    }
+  });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -43,7 +43,7 @@ const PORT = Number(process.env.HITL_CHANNEL_PORT ?? 8789);
 // triggering this module's top-level `await mcp.connect(...)`.
 import { MCP_INSTRUCTIONS } from "./mcp_instructions.js";
 
-const mcp = new Server(
+export const mcp = new Server(
   { name: "hitl-channel", version: "0.1.0" },
   {
     capabilities: {
@@ -197,6 +197,36 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
           },
         },
         required: ["name"],
+      },
+    },
+    {
+      name: "push_file",
+      description:
+        "Push a text file from the console filesystem to the phone's app storage. " +
+        "Gates the push on-device via a softConfirm approval sheet. Only text files are supported.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          local_path: {
+            type: "string",
+            description: "Absolute or relative path to the local file on the console.",
+          },
+          dest: {
+            type: "string",
+            description:
+              "Rooted relative path on the phone's storage (e.g. 'skills/my-skill/scripts/board.html', 'documents/notes.txt'). " +
+              "Must be relative/rooted (no arbitrary absolute paths).",
+          },
+          media_type: {
+            type: "string",
+            description: "Optional MIME type. If omitted, inferred from the file extension.",
+          },
+          overwrite: {
+            type: "boolean",
+            description: "Whether to overwrite the file on the phone if it already exists (default: true).",
+          },
+        },
+        required: ["local_path", "dest"],
       },
     },
     // ─── SPEC-HC-004 ─────────────────────────────────────────────────────
@@ -683,6 +713,295 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
           {
             type: "text" as const,
             text: `call_phone_tool failed: ${msg}`,
+          },
+        ],
+      };
+    }
+  }
+
+  if (req.params.name === "push_file") {
+    const localPath = args.local_path as string | undefined;
+    const dest = args.dest as string | undefined;
+    const overwrite = args.overwrite as boolean | undefined;
+
+    if (!localPath || typeof localPath !== "string") {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text" as const,
+            text: "push_file requires `local_path` (string).",
+          },
+        ],
+      };
+    }
+    if (!dest || typeof dest !== "string") {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text" as const,
+            text: "push_file requires `dest` (string).",
+          },
+        ],
+      };
+    }
+
+    // Host-path validation
+    const absolute = resolvePath(localPath);
+    let realAbsolute = absolute;
+    try {
+      realAbsolute = await realpath(absolute);
+    } catch {
+      // ignore
+    }
+    const roots = attachmentRoots();
+    if (!isPathAllowed(absolute, roots) || !isPathAllowed(realAbsolute, roots)) {
+      process.stderr.write(
+        `[hitl-channel] push_file: rejecting path outside allowlisted roots: ${absolute}\n`,
+      );
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text" as const,
+            text: `push_file failed: path outside allowlist: ${localPath}`,
+          },
+        ],
+      };
+    }
+
+    // Verify it is a file and meets size constraints
+    try {
+      const st = await stat(absolute);
+      if (!st.isFile()) {
+        process.stderr.write(
+          `[hitl-channel] push_file: path is not a regular file: ${absolute}\n`,
+        );
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `push_file failed: path is not a regular file: ${localPath}`,
+            },
+          ],
+        };
+      }
+      if (st.size > kMaxFileReadBytes) {
+        process.stderr.write(
+          `[hitl-channel] push_file: file size exceeds limit: ${absolute}\n`,
+        );
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `push_file failed: file size exceeds limit: ${localPath}`,
+            },
+          ],
+        };
+      }
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `[hitl-channel] push_file: failed to read metadata for ${absolute}: ${errMsg}\n`,
+      );
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text" as const,
+            text: `push_file failed: failed to read: ${localPath}`,
+          },
+        ],
+      };
+    }
+
+    if (clients.size === 0) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text" as const,
+            text: "No paired HITL phone is currently connected.",
+          },
+        ],
+      };
+    }
+
+    // Read the local file content as text
+    let fileContent: string;
+    try {
+      fileContent = await readFile(absolute, "utf8");
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `[hitl-channel] push_file: failed to read file ${absolute}: ${errMsg}\n`,
+      );
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text" as const,
+            text: `push_file failed: failed to read file contents: ${localPath}`,
+          },
+        ],
+      };
+    }
+
+    // Destination validation
+    const normalizedDest = dest.replace(/\\/g, "/").replace(/^\/+/, "");
+    if (normalizedDest.split("/").includes("..") || normalizedDest === "") {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text" as const,
+            text: `push_file failed: invalid destination path (must be relative and cannot contain ..): ${dest}`,
+          },
+        ],
+      };
+    }
+
+    // Determine target phone tool and build arguments
+    let phoneToolName = "write_file";
+    let phoneToolArgs: Record<string, unknown> = {};
+    const overwriteVal = overwrite !== false; // defaults to true
+
+    const parts = normalizedDest.split("/");
+    if (parts[0] === "skills" && parts.length >= 3) {
+      phoneToolName = "write_skill_file";
+      const skillName = parts[1];
+      const filePath = parts.slice(2).join("/");
+      phoneToolArgs = {
+        skillName,
+        skill_name: skillName,
+        filePath,
+        file_path: filePath,
+        path: filePath,
+        content: fileContent,
+        overwrite: overwriteVal,
+      };
+    } else {
+      phoneToolName = "write_file";
+      phoneToolArgs = {
+        path: normalizedDest,
+        filepath: normalizedDest,
+        filePath: normalizedDest,
+        content: fileContent,
+        overwrite: overwriteVal,
+      };
+    }
+
+    const timeoutSeconds = 60;
+    const requestId = generateRequestId();
+    const frame = {
+      type: "tool_call_request" as const,
+      request_id: requestId,
+      name: phoneToolName,
+      arguments: phoneToolArgs,
+      timeout_seconds: timeoutSeconds,
+      cc_instance_id: identity.instanceId,
+    };
+    const startedAt = Date.now();
+
+    // Audit the outgoing call
+    appendAudit({
+      ts: new Date(startedAt).toISOString(),
+      instance_id: identity.instanceId,
+      direction: "cc_calls_phone",
+      kind: "tool_call",
+      tool_name: phoneToolName,
+      approval: null,
+      prompt_hash: sha256Hex(stableStringify(phoneToolArgs)),
+      duration_ms: null,
+      attachment_count: 0,
+      attachment_bytes: 0,
+    }).catch((err) =>
+      process.stderr.write(
+        `[hitl-channel] audit failed: ${err instanceof Error ? err.message : err}\n`,
+      )
+    );
+
+    const waiter = correlator.register<ToolCallResultFrame>(
+      requestId,
+      timeoutSeconds * 1000,
+    );
+    const delivered = broadcastFrame(frame);
+    if (delivered === 0) {
+      correlator.reject(requestId, new Error("no_phone_connected_post_check"));
+    }
+
+    try {
+      const result = await waiter;
+      const duration = Date.now() - startedAt;
+
+      // Audit the incoming result
+      const { count: attachmentCount, bytes: attachmentBytes } =
+        summariseAttachments((result as { attachments?: unknown }).attachments);
+
+      appendAudit({
+        ts: new Date().toISOString(),
+        instance_id: identity.instanceId,
+        direction: "phone_returns_to_cc",
+        kind: "tool_result",
+        tool_name: phoneToolName,
+        approval: result.approval ?? null,
+        prompt_hash: sha256Hex(stableStringify(result.output ?? null)),
+        duration_ms: duration,
+        attachment_count: attachmentCount,
+        attachment_bytes: attachmentBytes,
+      }).catch((err) =>
+        process.stderr.write(
+          `[hitl-channel] audit failed: ${err instanceof Error ? err.message : err}\n`,
+        )
+      );
+
+      if (result.success === false) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  success: false,
+                  error: result.error ?? "unknown_error",
+                  approval: result.approval ?? null,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                success: true,
+                output: result.output ?? null,
+                approval: result.approval ?? null,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text" as const,
+            text: `push_file failed: ${msg}`,
           },
         ],
       };

--- a/src/server.ts
+++ b/src/server.ts
@@ -866,19 +866,24 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
       };
     }
 
+    // Inference of media type if not provided
+    let finalMediaType = mediaType;
+    if (!finalMediaType) {
+      const ext = extname(absolute).slice(1).toLowerCase();
+      finalMediaType = MIME_BY_EXT[ext] ?? "text/plain";
+    }
+
+    const mediaTypeArgs = {
+      mediaType: finalMediaType,
+      media_type: finalMediaType,
+      contentType: finalMediaType,
+      content_type: finalMediaType,
+    };
+
     // Determine target phone tool and build arguments
     let phoneToolName = "write_file";
     let phoneToolArgs: Record<string, unknown> = {};
     const overwriteVal = overwrite !== false; // defaults to true
-
-    const mediaTypeArgs = mediaType
-      ? {
-          mediaType,
-          media_type: mediaType,
-          contentType: mediaType,
-          content_type: mediaType,
-        }
-      : {};
 
     const parts = normalizedDest.split("/");
     if (parts[0] === "skills" && parts.length >= 3) {
@@ -920,6 +925,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
       cc_instance_id: identity.instanceId,
     };
     const startedAt = Date.now();
+    const inputHash = sha256Hex(stableStringify(phoneToolArgs));
 
     // Audit the outgoing call
     appendAudit({
@@ -929,7 +935,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
       kind: "tool_call",
       tool_name: phoneToolName,
       approval: null,
-      prompt_hash: sha256Hex(stableStringify(phoneToolArgs)),
+      prompt_hash: inputHash,
       duration_ms: null,
       attachment_count: 0,
       attachment_bytes: 0,
@@ -963,7 +969,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
         kind: "tool_result",
         tool_name: phoneToolName,
         approval: result.approval ?? null,
-        prompt_hash: sha256Hex(stableStringify(result.output ?? null)),
+        prompt_hash: inputHash, // Repeat original request's prompt_hash for correlation
         duration_ms: duration,
         attachment_count: attachmentCount,
         attachment_bytes: attachmentBytes,
@@ -1010,7 +1016,27 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
         ],
       };
     } catch (err) {
+      const duration = Date.now() - startedAt;
       const msg = err instanceof Error ? err.message : String(err);
+
+      // Audit the failure path
+      appendAudit({
+        ts: new Date().toISOString(),
+        instance_id: identity.instanceId,
+        direction: "phone_returns_to_cc",
+        kind: "tool_result",
+        tool_name: phoneToolName,
+        approval: msg.includes("timeout") ? "timeout" : null,
+        prompt_hash: inputHash, // Repeat original request's prompt_hash for correlation
+        duration_ms: duration,
+        attachment_count: 0,
+        attachment_bytes: 0,
+      }).catch((auditErr) =>
+        process.stderr.write(
+          `[hitl-channel] audit failed: ${auditErr instanceof Error ? auditErr.message : auditErr}\n`,
+        )
+      );
+
       return {
         isError: true,
         content: [

--- a/src/server.ts
+++ b/src/server.ts
@@ -723,6 +723,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
     const localPath = args.local_path as string | undefined;
     const dest = args.dest as string | undefined;
     const overwrite = args.overwrite as boolean | undefined;
+    const mediaType = args.media_type as string | undefined;
 
     if (!localPath || typeof localPath !== "string") {
       return {
@@ -818,6 +819,21 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
       };
     }
 
+    // Destination validation
+    const normalizedDest = dest.replace(/\\/g, "/").replace(/^\/+/, "");
+    const destParts = normalizedDest.split("/");
+    if (destParts.includes("..") || destParts.includes(".") || normalizedDest === "") {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text" as const,
+            text: `push_file failed: invalid destination path (must be relative and cannot contain .. or .): ${dest}`,
+          },
+        ],
+      };
+    }
+
     if (clients.size === 0) {
       return {
         isError: true,
@@ -850,24 +866,19 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
       };
     }
 
-    // Destination validation
-    const normalizedDest = dest.replace(/\\/g, "/").replace(/^\/+/, "");
-    if (normalizedDest.split("/").includes("..") || normalizedDest === "") {
-      return {
-        isError: true,
-        content: [
-          {
-            type: "text" as const,
-            text: `push_file failed: invalid destination path (must be relative and cannot contain ..): ${dest}`,
-          },
-        ],
-      };
-    }
-
     // Determine target phone tool and build arguments
     let phoneToolName = "write_file";
     let phoneToolArgs: Record<string, unknown> = {};
     const overwriteVal = overwrite !== false; // defaults to true
+
+    const mediaTypeArgs = mediaType
+      ? {
+          mediaType,
+          media_type: mediaType,
+          contentType: mediaType,
+          content_type: mediaType,
+        }
+      : {};
 
     const parts = normalizedDest.split("/");
     if (parts[0] === "skills" && parts.length >= 3) {
@@ -879,18 +890,22 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
         skill_name: skillName,
         filePath,
         file_path: filePath,
+        filepath: filePath,
         path: filePath,
         content: fileContent,
         overwrite: overwriteVal,
+        ...mediaTypeArgs,
       };
     } else {
       phoneToolName = "write_file";
       phoneToolArgs = {
         path: normalizedDest,
-        filepath: normalizedDest,
         filePath: normalizedDest,
+        file_path: normalizedDest,
+        filepath: normalizedDest,
         content: fileContent,
         overwrite: overwriteVal,
+        ...mediaTypeArgs,
       };
     }
 


### PR DESCRIPTION
Closes #26

This PR registers the 'push_file' tool on the hitl-channel MCP server. It allows console agents to transfer text files directly to the phone storage.

Key features:
1. Registers the 'push_file' tool on the MCP server.
2. Kept invisible to mobile agents/InternalToolsService.
3. Path validator is hardened and prevents symlink-escape attempts.
4. Correctly invokes write_skill_file for 'skills/' destination paths, and write_file for other paths.