### PR TITLE
fix: push_file — match on-device write_file/write_skill_file schemas

### DIFF
--- a/src/__tests__/push_file.test.ts
+++ b/src/__tests__/push_file.test.ts
@@ -202,12 +202,14 @@ describe("push_file MCP Tool", () => {
       expect(receivedFrame).not.toBeNull();
       expect(receivedFrame.type).toBe("tool_call_request");
       expect(receivedFrame.name).toBe("write_file");
-      // Arguments check
-      expect(receivedFrame.arguments.path).toBe("documents/foo.txt");
+      // Arguments must match the on-device write_file schema EXACTLY:
+      // { filename, content } — required keys, no aliases, no extras.
+      expect(receivedFrame.arguments.filename).toBe("documents/foo.txt");
       expect(receivedFrame.arguments.content).toBe("hello from push_file test");
-      expect(receivedFrame.arguments.overwrite).toBe(true);
-      expect(receivedFrame.arguments.media_type).toBe("text/javascript");
-      expect(receivedFrame.arguments.contentType).toBe("text/javascript");
+      expect(Object.keys(receivedFrame.arguments).sort()).toEqual([
+        "content",
+        "filename",
+      ]);
 
       // Resolve the waiter
       const activeId = receivedFrame.request_id;
@@ -265,15 +267,16 @@ describe("push_file MCP Tool", () => {
       expect(receivedFrame).not.toBeNull();
       expect(receivedFrame.type).toBe("tool_call_request");
       expect(receivedFrame.name).toBe("write_skill_file");
-      // Arguments check
-      expect(receivedFrame.arguments.skillName).toBe("my-awesome-skill");
-      expect(receivedFrame.arguments.filePath).toBe("scripts/main.js");
+      // write_skill_file is additionalProperties:false on-device — args must be
+      // EXACTLY { name, file_path, content }. Any extra key is rejected.
+      expect(receivedFrame.arguments.name).toBe("my-awesome-skill");
       expect(receivedFrame.arguments.file_path).toBe("scripts/main.js");
-      expect(receivedFrame.arguments.filepath).toBe("scripts/main.js");
       expect(receivedFrame.arguments.content).toBe("my skill script content");
-      expect(receivedFrame.arguments.overwrite).toBe(false);
-      expect(receivedFrame.arguments.media_type).toBe("application/javascript");
-      expect(receivedFrame.arguments.contentType).toBe("application/javascript");
+      expect(Object.keys(receivedFrame.arguments).sort()).toEqual([
+        "content",
+        "file_path",
+        "name",
+      ]);
 
       // Resolve the waiter
       const activeId = receivedFrame.request_id;
@@ -295,7 +298,7 @@ describe("push_file MCP Tool", () => {
     }
   });
 
-  it("should infer media_type from extension if omitted", async () => {
+  it("must not leak media_type/overwrite or alias keys into the phone args", async () => {
     const callHandler = (mcp as any)._requestHandlers.get("tools/call");
 
     const tempFile = "/tmp/hitl-infer-test.json";
@@ -319,6 +322,10 @@ describe("push_file MCP Tool", () => {
           arguments: {
             local_path: tempFile,
             dest: "documents/foo.json",
+            // These are accepted at the MCP boundary but the on-device
+            // write_file schema has no such keys — they must NOT be forwarded.
+            media_type: "application/json",
+            overwrite: false,
           },
         },
       });
@@ -327,9 +334,12 @@ describe("push_file MCP Tool", () => {
 
       expect(receivedFrame).not.toBeNull();
       expect(receivedFrame.type).toBe("tool_call_request");
-      // Arguments check - should infer application/json
-      expect(receivedFrame.arguments.media_type).toBe("application/json");
-      expect(receivedFrame.arguments.contentType).toBe("application/json");
+      expect(receivedFrame.name).toBe("write_file");
+      // No media_type / overwrite / path aliases may reach the phone.
+      expect(Object.keys(receivedFrame.arguments).sort()).toEqual([
+        "content",
+        "filename",
+      ]);
 
       // Resolve the waiter
       const activeId = receivedFrame.request_id;

--- a/src/server.ts
+++ b/src/server.ts
@@ -866,51 +866,31 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
       };
     }
 
-    // Inference of media type if not provided
-    let finalMediaType = mediaType;
-    if (!finalMediaType) {
-      const ext = extname(absolute).slice(1).toLowerCase();
-      finalMediaType = MIME_BY_EXT[ext] ?? "text/plain";
-    }
-
-    const mediaTypeArgs = {
-      mediaType: finalMediaType,
-      media_type: finalMediaType,
-      contentType: finalMediaType,
-      content_type: finalMediaType,
-    };
-
-    // Determine target phone tool and build arguments
+    // Determine target phone tool and build arguments.
+    // NOTE: argument keys must match the on-device InternalToolsService
+    // schemas EXACTLY (verified via list_phone_tools). write_skill_file is
+    // additionalProperties:false, so extra keys are rejected — do not add
+    // alias keys or media-type hints here.
     let phoneToolName = "write_file";
     let phoneToolArgs: Record<string, unknown> = {};
-    const overwriteVal = overwrite !== false; // defaults to true
 
     const parts = normalizedDest.split("/");
     if (parts[0] === "skills" && parts.length >= 3) {
+      // write_skill_file requires exactly: name, file_path, content
       phoneToolName = "write_skill_file";
       const skillName = parts[1];
       const filePath = parts.slice(2).join("/");
       phoneToolArgs = {
-        skillName,
-        skill_name: skillName,
-        filePath,
+        name: skillName,
         file_path: filePath,
-        filepath: filePath,
-        path: filePath,
         content: fileContent,
-        overwrite: overwriteVal,
-        ...mediaTypeArgs,
       };
     } else {
+      // write_file requires: filename, content
       phoneToolName = "write_file";
       phoneToolArgs = {
-        path: normalizedDest,
-        filePath: normalizedDest,
-        file_path: normalizedDest,
-        filepath: normalizedDest,
+        filename: normalizedDest,
         content: fileContent,
-        overwrite: overwriteVal,
-        ...mediaTypeArgs,
       };
     }
 


### PR DESCRIPTION
## Problem

`push_file` (#27) silently fails **after** the on-device approval sheet is tapped — the phone returns `missing_filename` and nothing is written. Reproduced live: approved on-device (`approval: user_approved`) → write rejected.

## Root cause

The console built `phoneToolArgs` by shotgunning alias keys, none of which match the real InternalToolsService schemas (verified via `list_phone_tools`):

| phone tool | requires | console sent |
|---|---|---|
| `write_file` | `filename`, `content` | `path`, `filePath`, `file_path`, `filepath` (no `filename`) → `missing_filename` |
| `write_skill_file` | exactly `name`, `file_path`, `content` (**additionalProperties:false**) | `skillName`, `skill_name`, `filePath`, `path`, `overwrite`, media-type aliases (no `name`, + extras rejected) |

The PR's tests asserted the *buggy* alias keys, so CI was green on a broken tool.

## Fix

- `write_file` branch → `{ filename: normalizedDest, content }`
- `write_skill_file` branch → exactly `{ name, file_path, content }`
- Dropped the dead media-type inference + alias spread (on-device tools accept neither).
- Tests rewritten to assert the **exact** arg key-set; added a regression guard that `media_type`/`overwrite` never leak into the phone args.

## Verification

- `bun test` — 106 pass / 0 fail; `tsc --noEmit` clean.
- Arg-key sets asserted against the live `list_phone_tools` schemas.
- **Device-CV (pending restart):** the running channel MCP holds the pre-fix code in memory; a true end-to-end re-push needs a channel restart, after which `push_file documents/<x>.txt` should land the file and a `skills/<s>/<f>` push should write to the skill dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)