### PR TITLE
fix: implement application-level ACK protocol for reliable delivery

### DIFF
--- a/src/__tests__/allowlist.test.ts
+++ b/src/__tests__/allowlist.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { homedir } from "node:os";
 import {
   hashToken,
   addToAllowlist,
@@ -16,7 +17,7 @@ describe("allowlist.ts", () => {
     // Clear allowlist before each test
     const allowlist = await loadAllowlist();
     allowlist.entries = {};
-    const file = Bun.file("~/.hitl/channels/allowlist.json");
+    const file = Bun.file(`${homedir()}/.hitl/channels/allowlist.json`);
     await Bun.write(file, JSON.stringify(allowlist, null, 2));
   });
 

--- a/src/__tests__/reply_buffer.test.ts
+++ b/src/__tests__/reply_buffer.test.ts
@@ -158,7 +158,11 @@ describe("ReplyBuffer — SPEC-HITL-CC-001 AC#26", () => {
   // The buffer used to call `drain()` (destructive clear) BEFORE confirming
   // ws.send succeeded. If the WS dropped mid-loop, remaining entries were
   // permanently lost. peek + commit now leaves un-sent entries in the buffer.
-  it("P0 regression: partial-send (ws dies mid-loop) leaves remaining entries in buffer", () => {
+  // ─── P0 regression: peek + per-entry commit ───────────────────────────
+  // Under the new ACK-based protocol, entries are NOT committed/deleted during
+  // drainBufferToClientSync. They stay in the buffer until an explicit ACK
+  // control frame is received.
+  it("P0 regression: partial-send (ws dies mid-loop) leaves remaining entries in buffer until ACKed", () => {
     const buf = new ReplyBuffer();
     buf.push(makeReply("a", "m1", "agentA", "1"));
     buf.push(makeReply("b", "m2", "agentA", "2"));
@@ -180,7 +184,12 @@ describe("ReplyBuffer — SPEC-HITL-CC-001 AC#26", () => {
     const { sent: sentCount } = drainBufferToClientSync(ws, buf);
     expect(sentCount).toBe(1);          // only the first entry was sent
     expect(sent.length).toBe(1);
-    expect(buf.size()).toBe(2);         // m2 + m3 still in buffer for next reconnect
+    expect(buf.size()).toBe(3);         // Still 3 because no ACKs have been received!
+
+    // Client ACKs the first message (id: 'r-1')
+    const firstPayload = JSON.parse(sent[0]) as ReplyPayload;
+    expect(buf.commitById(firstPayload.id)).toBe(true);
+    expect(buf.size()).toBe(2);         // Now 2
 
     // Second reconnect: a healthy WS drains the rest.
     const { ws: ws2, sent: sent2 } = makeFakeWs();
@@ -189,6 +198,13 @@ describe("ReplyBuffer — SPEC-HITL-CC-001 AC#26", () => {
     expect(sent2.length).toBe(2);
     const ids = sent2.map((s) => JSON.parse(s).message_id);
     expect(ids).toEqual(["m2", "m3"]);
+    expect(buf.size()).toBe(2);         // Still 2 because they are not ACKed yet!
+
+    // Client ACKs the remaining two messages
+    for (const s of sent2) {
+      const payload = JSON.parse(s) as ReplyPayload;
+      expect(buf.commitById(payload.id)).toBe(true);
+    }
     expect(buf.size()).toBe(0);
   });
 
@@ -220,15 +236,12 @@ describe("ReplyBuffer — SPEC-HITL-CC-001 AC#26", () => {
     expect(n).toBe(2);                       // 2 actually sent
     expect(auditCalls.length).toBe(1);
     expect(auditCalls[0]!.replies_drained).toBe(2); // not 3 (the peek snapshot length)
-    expect(buf.size()).toBe(1);              // m3 still buffered
+    expect(buf.size()).toBe(3);              // m3 and others still buffered
   });
 
   // ─── P1#2 regression: concurrent drains are safe ──────────────────────
-  // Removing the `clients.size === 1` guard relies on peek+commit being
-  // idempotent: a second drainer sees an empty buffer (the first drainer
-  // already committed every entry) and returns zero. No double-send, no
-  // audit double-emit.
-  it("P1#2 regression: a second sync drain on the same buffer returns zero and emits no double-send", () => {
+  // Since drain no longer commits, a reconnect redelivers until ACKed.
+  it("P1#2 regression: a second sync drain on the same buffer redelivers until ACKed", () => {
     const buf = new ReplyBuffer();
     buf.push(makeReply("a", "m1", "agentA", "1"));
     buf.push(makeReply("b", "m2", "agentA", "2"));
@@ -238,11 +251,23 @@ describe("ReplyBuffer — SPEC-HITL-CC-001 AC#26", () => {
     expect(r1.sent).toBe(2);
     expect(sent1.length).toBe(2);
 
+    // If we drain again without ACKing, it should redeliver
     const { ws: ws2, sent: sent2 } = makeFakeWs();
     const r2 = drainBufferToClientSync(ws2, buf);
-    expect(r2.sent).toBe(0);
-    expect(r2.oldestQueuedAt).toBeNull();
-    expect(sent2.length).toBe(0);
+    expect(r2.sent).toBe(2);
+    expect(sent2.length).toBe(2);
+
+    // Now ACK the messages
+    for (const s of sent1) {
+      const payload = JSON.parse(s) as ReplyPayload;
+      expect(buf.commitById(payload.id)).toBe(true);
+    }
+
+    // A third drain should return zero because they are now committed/ACKed
+    const { ws: ws3, sent: sent3 } = makeFakeWs();
+    const r3 = drainBufferToClientSync(ws3, buf);
+    expect(r3.sent).toBe(0);
+    expect(sent3.length).toBe(0);
   });
 
   // ─── P1 regression: ws.send return value gates commit ─────────────────
@@ -269,12 +294,25 @@ describe("ReplyBuffer — SPEC-HITL-CC-001 AC#26", () => {
     const r1 = drainBufferToClientSync(ws, buf);
     expect(r1.sent).toBe(1);
     expect(accepted.length).toBe(1);
+    expect(buf.size()).toBe(3); // Still 3
+
+    // ACK the first one
+    const firstPayload = JSON.parse(accepted[0]) as ReplyPayload;
+    expect(buf.commitById(firstPayload.id)).toBe(true);
     expect(buf.size()).toBe(2);
 
+    // Second reconnect drains the remaining 2
     const { ws: ws2, sent: sent2 } = makeFakeWs();
     const r2 = drainBufferToClientSync(ws2, buf);
     expect(r2.sent).toBe(2);
     expect(sent2.map((s) => JSON.parse(s).message_id)).toEqual(["m2", "m3"]);
+    expect(buf.size()).toBe(2); // Still 2 until ACKed
+
+    // ACK the rest
+    for (const s of sent2) {
+      const payload = JSON.parse(s) as ReplyPayload;
+      expect(buf.commitById(payload.id)).toBe(true);
+    }
     expect(buf.size()).toBe(0);
   });
 

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -135,7 +135,7 @@ describe("hitl-channel HTTP Bridge", () => {
     expect(response.status).toBe(400);
   });
 
-  it("WebSocket should connect and receive replies", async () => {
+  it("WebSocket should connect, receive replies, and commit them on ACK", async () => {
     return new Promise<void>((resolve, reject) => {
       const ws = new WebSocket(`ws://127.0.0.1:${TEST_PORT}/ws?api_key=${TEST_API_KEY}`);
       
@@ -152,8 +152,26 @@ describe("hitl-channel HTTP Bridge", () => {
           expect(data.text).toBe("test reply");
           expect(data.message_id).toBe("msg1");
           expect(data.agent_id).toBe("agent1");
-          ws.close();
-          resolve();
+          
+          import("../http_bridge.js").then(({ replyBuffer }) => {
+            // Verify it was pushed to the buffer
+            expect(replyBuffer.size()).toBe(1);
+            
+            // Send application-level ACK
+            ws.send(JSON.stringify({ type: "ack", id: data.id }));
+            
+            // Wait for server to process ACK and remove from buffer
+            setTimeout(() => {
+              try {
+                expect(replyBuffer.size()).toBe(0);
+                ws.close();
+                resolve();
+              } catch (err) {
+                ws.close();
+                reject(err);
+              }
+            }, 50);
+          }).catch(reject);
         } catch (err) {
           ws.close();
           reject(err);

--- a/src/http_bridge.ts
+++ b/src/http_bridge.ts
@@ -110,17 +110,15 @@ export function broadcastReply(
     ts: new Date().toISOString(),
     ...(attachments && attachments.length > 0 ? { attachments } : {}),
   };
+  
+  // Always push to buffer first to guarantee redundancy
+  replyBuffer.push(payload);
+
   const rawPayload = JSON.stringify(payload);
-  let sent = 0;
   for (const ws of clients) {
-    if (ws.readyState === 1 && wsSendAccepted(ws, rawPayload)) {
-      sent++;
+    if (ws.readyState === 1) {
+      wsSendAccepted(ws, rawPayload);
     }
-  }
-  // SPEC-HITL-CC-001 Phase 4 AC#26 — instead of silently dropping when no
-  // OPEN WS client received the frame, queue for replay on next WS reconnect.
-  if (sent === 0) {
-    replyBuffer.push(payload);
   }
 }
 
@@ -158,7 +156,6 @@ export function drainBufferToClientSync(
     // entry.raw is the JSON.stringify(payload) cached at push time —
     // re-using it avoids re-serializing on every reconnect.
     if (!wsSendAccepted(ws, entry.raw)) break;
-    buffer.commit(entry);
     sent++;
   }
   return { sent, oldestQueuedAt: sent > 0 ? oldestQueuedAt : null };
@@ -520,6 +517,18 @@ export function startHttpBridge(mcp: Server) {
           // request_id is logged at warn level and dropped (no waiter, no
           // audit double-count) per the idempotency contract.
           const frameType = typeof data.type === "string" ? data.type : undefined;
+          if (frameType === "ack") {
+            const id = typeof data.id === "string" ? data.id : undefined;
+            if (!id) {
+              process.stderr.write(`[hitl-channel] WARN ack missing id — dropped\n`);
+              return;
+            }
+            const removed = replyBuffer.commitById(id);
+            if (!removed) {
+              process.stderr.write(`[hitl-channel] WARN ack for unknown id ${id}\n`);
+            }
+            return;
+          }
           if (
             frameType === "tool_call_result" ||
             frameType === "list_tools_result" ||

--- a/src/reply_buffer.ts
+++ b/src/reply_buffer.ts
@@ -110,6 +110,24 @@ export class ReplyBuffer {
   }
 
   /**
+   * Remove a reply from the buffer by its unique ID.
+   * Returns true if found and removed; false if already absent.
+   */
+  commitById(id: string): boolean {
+    for (const [key, bucket] of this.buckets.entries()) {
+      const idx = bucket.findIndex((e) => e.payload.id === id);
+      if (idx !== -1) {
+        bucket.splice(idx, 1);
+        if (bucket.length === 0) {
+          this.buckets.delete(key);
+        }
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Convenience: peek + commit-all in one call. Returns live entries in
    * arrival order and removes them from the buffer. Expired entries are
    * dropped silently.


### PR DESCRIPTION
## Summary
This PR implements the application-level ACK protocol for reliable delivery as specified in issue #34.

### Key Changes
1. Added `commitById(id: string): boolean` to `ReplyBuffer` to allow removing a reply from the buffer by its unique ID.
2. In `broadcastReply`, modified the flow to always push the reply to the `replyBuffer` first for redundancy before attempting to broadcast to active WS clients.
3. In `drainBufferToClientSync`, modified the flow to keep buffered replies in the buffer rather than committing them automatically on send.
4. In the WebSocket `message` handler, added support for `type: "ack"` control frames, which trigger `replyBuffer.commitById(id)` to delete/commit the message.
5. Updated unit tests in `src/__tests__/reply_buffer.test.ts` to reflect the ACK-based contract, including mock ACK triggers.
6. Updated integration tests in `src/__tests__/server.test.ts` to cover E2E WS connect, broadcast, and ACK commit flows.
7. Fixed allowlist path resolution in `src/__tests__/allowlist.test.ts` by using `homedir()`.

Refs #34