### PR TITLE
fix: persist phone→CC file attachments (not just images)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ node_modules/
 .claude/
 !.claude/empire_context.yaml
 .gemini/
+.grok/
+.agent_task/
 "~"/

--- a/src/__tests__/process_attachments.test.ts
+++ b/src/__tests__/process_attachments.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Issue #36 — phone→CC file attachments must persist for type:"file" as well
+ * as type:"image", with path-traversal-safe names and accurate WS audit rows.
+ *
+ * AV1–AV5 from the issue Agent Verification criteria.
+ */
+import {
+  describe,
+  expect,
+  it,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from "bun:test";
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  processAttachments,
+  sanitizeAttachmentFileName,
+  startHttpBridge,
+} from "../http_bridge.js";
+
+function b64(s: string): string {
+  return Buffer.from(s, "utf8").toString("base64");
+}
+
+describe("sanitizeAttachmentFileName", () => {
+  it("returns fallback for empty / missing names", () => {
+    expect(sanitizeAttachmentFileName(undefined, "fb.bin")).toBe("fb.bin");
+    expect(sanitizeAttachmentFileName("", "fb.bin")).toBe("fb.bin");
+  });
+
+  it("strips path traversal and absolute prefixes to basename only", () => {
+    expect(sanitizeAttachmentFileName("../../evil.sh", "fb.bin")).toBe(
+      "evil.sh",
+    );
+    expect(sanitizeAttachmentFileName("/etc/passwd", "fb.bin")).toBe("passwd");
+    expect(sanitizeAttachmentFileName("a/b/c.json", "fb.bin")).toBe("c.json");
+    expect(sanitizeAttachmentFileName("..\\..\\evil.bat", "fb.bin")).toBe(
+      "evil.bat",
+    );
+  });
+
+  it("strips leading dots so names cannot hide or reintroduce ..", () => {
+    expect(sanitizeAttachmentFileName("..", "fb.bin")).toBe("fb.bin");
+    expect(sanitizeAttachmentFileName(".", "fb.bin")).toBe("fb.bin");
+    expect(sanitizeAttachmentFileName("...hidden", "fb.bin")).toBe("hidden");
+  });
+});
+
+describe("processAttachments (unit — AV1–AV4)", () => {
+  let homeDir: string;
+  let inboxDir: string;
+  let prevHome: string | undefined;
+
+  beforeEach(async () => {
+    homeDir = await mkdtemp(join(tmpdir(), "hitl-att-"));
+    prevHome = process.env.HOME;
+    process.env.HOME = homeDir;
+    inboxDir = join(homeDir, ".claude", "channels", "hitl-channel", "inbox");
+  });
+
+  afterEach(async () => {
+    process.env.HOME = prevHome;
+    await rm(homeDir, { recursive: true, force: true });
+  });
+
+  it("AV1: type:file (application/json) writes decoded bytes and [File: path] marker", async () => {
+    const jsonBody = '{"hello":"world"}';
+    const content = await processAttachments("Please analyze the attached file.", [
+      {
+        type: "file",
+        media_type: "application/json",
+        data: b64(jsonBody),
+        fileName: "payload.json",
+      },
+    ]);
+
+    const expectedPath = join(inboxDir, "payload.json");
+    expect(content).toContain("[File: " + expectedPath + "]");
+    expect(content).toContain("Please analyze the attached file.");
+    const onDisk = await readFile(expectedPath, "utf8");
+    expect(onDisk).toBe(jsonBody);
+  });
+
+  it("AV2: type:image still produces [Image: path] with identical bytes (regression)", async () => {
+    // Minimal 1x1 PNG
+    const pngBytes = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+      "base64",
+    );
+    const content = await processAttachments("see image", [
+      {
+        type: "image",
+        media_type: "image/png",
+        data: pngBytes.toString("base64"),
+        fileName: "dot.png",
+      },
+    ]);
+
+    const expectedPath = join(inboxDir, "dot.png");
+    expect(content).toContain("[Image: " + expectedPath + "]");
+    expect(content).not.toContain("[File:");
+    const onDisk = await readFile(expectedPath);
+    expect(Buffer.compare(onDisk, pngBytes)).toBe(0);
+  });
+
+  it("AV3: traversal-hostile fileName is confined to the inbox dir", async () => {
+    const body = "#!/bin/sh\necho pwned\n";
+    for (const hostile of [
+      "../../evil.sh",
+      "/tmp/absolute.sh",
+      "nested/../escape.sh",
+      "a/b/c/deep.txt",
+    ]) {
+      const content = await processAttachments("msg", [
+        {
+          type: "file",
+          media_type: "application/x-sh",
+          data: b64(body),
+          fileName: hostile,
+        },
+      ]);
+      const match = content.match(/\[File: ([^\]]+)\]/);
+      expect(match).not.toBeNull();
+      const writtenPath = match![1]!;
+      expect(writtenPath.startsWith(inboxDir + "/")).toBe(true);
+      expect(writtenPath.includes("..")).toBe(false);
+      // Only basename should remain under inbox.
+      const base = writtenPath.slice(inboxDir.length + 1);
+      expect(base.includes("/")).toBe(false);
+      const onDisk = await readFile(writtenPath, "utf8");
+      expect(onDisk).toBe(body);
+    }
+  });
+
+  it("AV4: attachment without data is skipped with stderr warning; message still delivered", async () => {
+    const stderrChunks: string[] = [];
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array, ...args: unknown[]) => {
+      stderrChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString());
+      return (origWrite as (c: string | Uint8Array, ...a: unknown[]) => boolean)(
+        chunk,
+        ...args,
+      );
+    }) as typeof process.stderr.write;
+
+    try {
+      const content = await processAttachments("text only survives", [
+        {
+          type: "file",
+          media_type: "application/json",
+          data: "", // empty → treated as missing
+          fileName: "empty.json",
+        } as { type: string; media_type: string; data: string; fileName: string },
+        {
+          type: "file",
+          media_type: "application/json",
+          // data omitted
+          fileName: "nodata.json",
+        } as { type: string; media_type: string; data: string; fileName: string },
+      ]);
+
+      expect(content).toBe("text only survives");
+      expect(content).not.toContain("[File:");
+      const warning = stderrChunks.join("");
+      expect(warning).toMatch(/Skipping attachment \(missing data\)/);
+
+      // Inbox may exist but should not contain the skipped names as payloads
+      // (mkdir happens up front if there are attachments).
+      try {
+        const files = await readdir(inboxDir);
+        expect(files).not.toContain("empty.json");
+        expect(files).not.toContain("nodata.json");
+      } catch {
+        // inbox may not exist if we short-circuit — also fine
+      }
+    } finally {
+      process.stderr.write = origWrite;
+    }
+  });
+
+  it("persists non-image types other than file (e.g. application/pdf as type:document)", async () => {
+    const pdfMagic = "%PDF-1.4 fake";
+    const content = await processAttachments("pdf please", [
+      {
+        type: "document",
+        media_type: "application/pdf",
+        data: b64(pdfMagic),
+        fileName: "report.pdf",
+      },
+    ]);
+    const expectedPath = join(inboxDir, "report.pdf");
+    expect(content).toContain("[File: " + expectedPath + "]");
+    expect(await readFile(expectedPath, "utf8")).toBe(pdfMagic);
+  });
+});
+
+describe("POST / + WS chat attachments (integration AV1 + AV5)", () => {
+  const TEST_PORT = 8796;
+  const TEST_API_KEY = "test-key-attachments-36";
+  let server: ReturnType<typeof startHttpBridge>;
+  let lastNotification: { params?: { content?: string } } | null = null;
+  let homeDir: string;
+  let prevHome: string | undefined;
+  let prevPort: string | undefined;
+  let prevKey: string | undefined;
+  let prevInstance: string | undefined;
+
+  beforeAll(async () => {
+    homeDir = await mkdtemp(join(tmpdir(), "hitl-att-http-"));
+    prevHome = process.env.HOME;
+    prevPort = process.env.HITL_CHANNEL_PORT;
+    prevKey = process.env.HITL_CHANNEL_API_KEY;
+    prevInstance = process.env.HITL_INSTANCE_ID;
+    process.env.HOME = homeDir;
+    process.env.HITL_CHANNEL_PORT = String(TEST_PORT);
+    process.env.HITL_CHANNEL_API_KEY = TEST_API_KEY;
+    process.env.HITL_INSTANCE_ID = "instance-att-36";
+
+    const mcpMock = {
+      notification: async (notif: unknown) => {
+        lastNotification = notif as { params?: { content?: string } };
+      },
+    } as unknown as Server;
+    server = startHttpBridge(mcpMock);
+  });
+
+  afterAll(async () => {
+    server.stop(true);
+    process.env.HOME = prevHome;
+    process.env.HITL_CHANNEL_PORT = prevPort;
+    process.env.HITL_CHANNEL_API_KEY = prevKey;
+    process.env.HITL_INSTANCE_ID = prevInstance;
+    await rm(homeDir, { recursive: true, force: true });
+  });
+
+  it("AV1 via POST /: file attachment lands in inbox and notification content has [File:]", async () => {
+    lastNotification = null;
+    const jsonBody = '{"from":"post"}';
+    const response = await fetch(`http://127.0.0.1:${TEST_PORT}/`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${TEST_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        message: "Please analyze the attached file.",
+        attachments: [
+          {
+            type: "file",
+            media_type: "application/json",
+            data: b64(jsonBody),
+            fileName: "from_post.json",
+          },
+        ],
+      }),
+    });
+    expect(response.status).toBe(200);
+    // notification is awaited inside the POST handler before response
+    expect(lastNotification).not.toBeNull();
+    const content = lastNotification!.params!.content!;
+    expect(content).toContain("[File:");
+    expect(content).toContain("from_post.json");
+    const inboxPath = join(
+      homeDir,
+      ".claude",
+      "channels",
+      "hitl-channel",
+      "inbox",
+      "from_post.json",
+    );
+    expect(await readFile(inboxPath, "utf8")).toBe(jsonBody);
+  });
+
+  it("AV5: WS chat-branch audit row carries real attachment_count/bytes", async () => {
+    // audit.ts captures AUDIT_DIR via os.homedir() at module load — not
+    // process.env.HOME from this suite. Match our row by instance_id.
+    const auditFile = join(
+      homedir(),
+      ".hitl",
+      "channels",
+      "audit",
+      `${new Date().toISOString().slice(0, 10)}.jsonl`,
+    );
+    const instanceId = "instance-att-36";
+    const marker = `av5-ws-${Date.now()}`;
+
+    const raw = "ws-payload-bytes!!";
+    const dataB64 = b64(raw);
+    const expectedBytes = Buffer.byteLength(dataB64, "base64");
+
+    const ws = new WebSocket(
+      `ws://127.0.0.1:${TEST_PORT}/ws?api_key=${TEST_API_KEY}`,
+    );
+    await new Promise<void>((resolve, reject) => {
+      ws.onopen = () => resolve();
+      ws.onerror = (e) => reject(e);
+    });
+
+    try {
+      ws.send(
+        JSON.stringify({
+          message: marker,
+          attachments: [
+            {
+              type: "file",
+              media_type: "text/plain",
+              data: dataB64,
+              fileName: "ws.txt",
+            },
+          ],
+        }),
+      );
+
+      // Audit is fire-and-forget; poll briefly for our instance_id row.
+      let row: {
+        attachment_count?: number;
+        attachment_bytes?: number;
+        direction?: string;
+        kind?: string;
+        instance_id?: string;
+        prompt_hash?: string;
+      } | null = null;
+      const { sha256Hex } = await import("../audit.js");
+      const expectedHash = sha256Hex(marker);
+
+      for (let i = 0; i < 40; i++) {
+        await new Promise((r) => setTimeout(r, 25));
+        try {
+          const text = await readFile(auditFile, "utf8");
+          const lines = text
+            .trim()
+            .split("\n")
+            .filter(Boolean)
+            .map((l) => JSON.parse(l) as NonNullable<typeof row>);
+          const hit = lines.find(
+            (l) =>
+              l.instance_id === instanceId &&
+              l.direction === "phone_to_cc" &&
+              l.kind === "message" &&
+              l.prompt_hash === expectedHash,
+          );
+          if (hit) {
+            row = hit;
+            break;
+          }
+        } catch {
+          // file not ready yet
+        }
+      }
+
+      expect(row).not.toBeNull();
+      expect(row!.attachment_count).toBe(1);
+      expect(row!.attachment_bytes).toBe(expectedBytes);
+    } finally {
+      ws.close();
+    }
+  });
+});

--- a/src/__tests__/process_attachments.test.ts
+++ b/src/__tests__/process_attachments.test.ts
@@ -49,6 +49,13 @@ describe("sanitizeAttachmentFileName", () => {
     expect(sanitizeAttachmentFileName(".", "fb.bin")).toBe("fb.bin");
     expect(sanitizeAttachmentFileName("...hidden", "fb.bin")).toBe("hidden");
   });
+
+  it("rejects separator-only names that would collapse join() to the inbox dir", () => {
+    expect(sanitizeAttachmentFileName("/", "fb.bin")).toBe("fb.bin");
+    expect(sanitizeAttachmentFileName("//", "fb.bin")).toBe("fb.bin");
+    expect(sanitizeAttachmentFileName("\\", "fb.bin")).toBe("fb.bin");
+    expect(sanitizeAttachmentFileName("\\\\", "fb.bin")).toBe("fb.bin");
+  });
 });
 
 describe("processAttachments (unit — AV1–AV4)", () => {
@@ -181,6 +188,28 @@ describe("processAttachments (unit — AV1–AV4)", () => {
     } finally {
       process.stderr.write = origWrite;
     }
+  });
+
+  it("separator-only fileName falls back to timestamp name (strict inbox child)", async () => {
+    const body = "not a directory write";
+    const content = await processAttachments("sep", [
+      {
+        type: "file",
+        media_type: "text/plain",
+        data: b64(body),
+        fileName: "/",
+      },
+    ]);
+    const match = content.match(/\[File: ([^\]]+)\]/);
+    expect(match).not.toBeNull();
+    const writtenPath = match![1]!;
+    expect(writtenPath.startsWith(inboxDir + "/")).toBe(true);
+    expect(writtenPath).not.toBe(inboxDir);
+    // Must be a file under inbox, not the directory itself.
+    const base = writtenPath.slice(inboxDir.length + 1);
+    expect(base.length).toBeGreaterThan(0);
+    expect(base.includes("/")).toBe(false);
+    expect(await readFile(writtenPath, "utf8")).toBe(body);
   });
 
   it("persists non-image types other than file (e.g. application/pdf as type:document)", async () => {

--- a/src/http_bridge.ts
+++ b/src/http_bridge.ts
@@ -1,3 +1,4 @@
+import { basename, join, resolve } from "node:path";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { sendChannelNotification } from "./notification.js";
 import { HitlAttachment, HitlMessage, HitlWebSocket, ReplyPayload } from "./types.js";
@@ -187,35 +188,113 @@ export async function drainBufferToClient(
 }
 
 /**
- * Save image attachments to the inbox directory and return updated content
- * with file paths appended.
+ * Sanitize a phone-supplied attachment filename so it cannot escape the
+ * inbox directory via path traversal (inbound sibling of #25 outbound
+ * allowlist hardening). Basename-only; strip leading dots / null bytes.
+ * Falls back to `fallback` when the result is empty after sanitization.
  */
-async function processAttachments(
+export function sanitizeAttachmentFileName(
+  fileName: string | undefined,
+  fallback: string,
+): string {
+  if (!fileName || typeof fileName !== "string") return fallback;
+  // Normalize Windows separators then take basename (handles absolute + ../).
+  const base = basename(fileName.replace(/\\/g, "/"));
+  const cleaned = base.replace(/^\.+/, "").replace(/\0/g, "");
+  if (!cleaned) return fallback;
+  return cleaned;
+}
+
+function extensionFromMediaType(
+  mediaType: string | undefined,
+  isImage: boolean,
+): string {
+  const raw = mediaType?.includes("/")
+    ? (mediaType.split("/")[1]?.split(";")[0] ?? "")
+    : "";
+  const ext = raw.replace(/[^a-zA-Z0-9]/g, "");
+  if (ext) return ext;
+  return isImage ? "jpg" : "bin";
+}
+
+/**
+ * Save attachments (images + files) to the inbox directory and return
+ * updated content with file paths appended as `[Image: …]` / `[File: …]`.
+ *
+ * Every attachment with non-empty `data` is persisted — not just `type=image`.
+ * Phone codec (SPEC-HITL-CC-001 Phase 6 AC#31) stamps `type: "file"` for
+ * non-image mimes; silent fall-through was the #36 bug.
+ */
+export async function processAttachments(
   message: string,
-  attachments?: HitlAttachment[]
+  attachments?: HitlAttachment[],
 ): Promise<string> {
   if (!attachments || attachments.length === 0) return message;
 
-  const inboxDir = `${process.env.HOME}/.claude/channels/hitl-channel/inbox`;
+  const inboxDir = join(
+    process.env.HOME ?? "",
+    ".claude",
+    "channels",
+    "hitl-channel",
+    "inbox",
+  );
   await Bun.$`mkdir -p ${inboxDir}`.quiet();
+  const resolvedInbox = resolve(inboxDir);
 
   let contentForNotification = message;
 
   for (const attachment of attachments) {
-    if (attachment.type === "image" && attachment.data) {
-      const ext = attachment.media_type?.split("/")[1] || "jpg";
-      const fileName =
-        attachment.fileName || `img_${Date.now()}.${ext}`;
-      const filePath = `${inboxDir}/${fileName}`;
-
-      const buffer = Buffer.from(attachment.data, "base64");
-      await Bun.write(filePath, buffer);
-
-      contentForNotification += `\n\n[Image: ${filePath}]`;
+    if (!attachment || typeof attachment !== "object") {
       process.stderr.write(
-        `[hitl-channel] Saved image: ${filePath} (${buffer.length} bytes)\n`
+        `[hitl-channel] Skipping attachment (invalid entry)\n`,
       );
+      continue;
     }
+
+    if (!attachment.data || typeof attachment.data !== "string") {
+      process.stderr.write(
+        `[hitl-channel] Skipping attachment (missing data): type=${attachment.type ?? "unknown"} fileName=${attachment.fileName ?? "(none)"}\n`,
+      );
+      continue;
+    }
+
+    const isImage = attachment.type === "image";
+    const ext = extensionFromMediaType(attachment.media_type, isImage);
+    const fallback = isImage
+      ? `img_${Date.now()}.${ext}`
+      : `file_${Date.now()}.${ext}`;
+    const fileName = sanitizeAttachmentFileName(attachment.fileName, fallback);
+    const filePath = join(inboxDir, fileName);
+    const resolvedPath = resolve(filePath);
+
+    // Defense in depth: refuse any path that escapes the inbox after join.
+    if (
+      resolvedPath !== resolvedInbox &&
+      !resolvedPath.startsWith(resolvedInbox + "/")
+    ) {
+      process.stderr.write(
+        `[hitl-channel] Skipping attachment (path escapes inbox): fileName=${fileName}\n`,
+      );
+      continue;
+    }
+
+    let buffer: Buffer;
+    try {
+      buffer = Buffer.from(attachment.data, "base64");
+    } catch (err) {
+      process.stderr.write(
+        `[hitl-channel] Skipping attachment (base64 decode failed): fileName=${fileName} ${err instanceof Error ? err.message : err}\n`,
+      );
+      continue;
+    }
+
+    await Bun.write(filePath, buffer);
+
+    const marker = isImage ? "Image" : "File";
+    contentForNotification += `\n\n[${marker}: ${filePath}]`;
+    process.stderr.write(
+      `[hitl-channel] Saved ${isImage ? "image" : "file"}: ${filePath} (${buffer.length} bytes)\n`,
+    );
   }
 
   return contentForNotification;
@@ -641,6 +720,10 @@ export function startHttpBridge(mcp: Server) {
 
           const message = data.message?.trim() || data.content?.trim();
           if (message || (data.attachments && data.attachments.length > 0)) {
+            // Parity with POST /: real attachment_count/bytes via summariseAttachments
+            // (was hardcoded 0/0 — audit overstated delivery of dropped files, #36 AV5).
+            const { count: chatAttachmentCount, bytes: chatAttachmentBytes } =
+              summariseAttachments(data.attachments);
             processAttachments(message ?? "", data.attachments)
               .then((content) =>
                 sendChannelNotification(mcp, content, {
@@ -662,8 +745,8 @@ export function startHttpBridge(mcp: Server) {
               approval: null,
               prompt_hash: sha256Hex(message ?? ""),
               duration_ms: null,
-              attachment_count: 0,
-              attachment_bytes: 0,
+              attachment_count: chatAttachmentCount,
+              attachment_bytes: chatAttachmentBytes,
             }).catch((err) =>
               process.stderr.write(
                 `[hitl-channel] audit failed: ${err instanceof Error ? err.message : err}\n`

--- a/src/http_bridge.ts
+++ b/src/http_bridge.ts
@@ -190,8 +190,9 @@ export async function drainBufferToClient(
 /**
  * Sanitize a phone-supplied attachment filename so it cannot escape the
  * inbox directory via path traversal (inbound sibling of #25 outbound
- * allowlist hardening). Basename-only; strip leading dots / null bytes.
- * Falls back to `fallback` when the result is empty after sanitization.
+ * allowlist hardening). Basename-only; strip leading dots / null bytes /
+ * residual path separators. Falls back to `fallback` when the result is
+ * empty or not a safe single path segment.
  */
 export function sanitizeAttachmentFileName(
   fileName: string | undefined,
@@ -199,9 +200,14 @@ export function sanitizeAttachmentFileName(
 ): string {
   if (!fileName || typeof fileName !== "string") return fallback;
   // Normalize Windows separators then take basename (handles absolute + ../).
+  // Note: on some platforms basename("/") is "/" (not ""); strip separators
+  // explicitly so join(inbox, name) can never collapse to the inbox dir.
   const base = basename(fileName.replace(/\\/g, "/"));
-  const cleaned = base.replace(/^\.+/, "").replace(/\0/g, "");
-  if (!cleaned) return fallback;
+  const cleaned = base
+    .replace(/^\.+/, "")
+    .replace(/\0/g, "")
+    .replace(/[/\\]/g, "");
+  if (!cleaned || cleaned === "." || cleaned === "..") return fallback;
   return cleaned;
 }
 
@@ -264,16 +270,25 @@ export async function processAttachments(
       ? `img_${Date.now()}.${ext}`
       : `file_${Date.now()}.${ext}`;
     const fileName = sanitizeAttachmentFileName(attachment.fileName, fallback);
+    // Reject residual separator / empty segments even if sanitize regresses.
+    if (!fileName || fileName.includes("/") || fileName.includes("\\")) {
+      process.stderr.write(
+        `[hitl-channel] Skipping attachment (unsafe fileName after sanitize): fileName=${fileName}\n`,
+      );
+      continue;
+    }
     const filePath = join(inboxDir, fileName);
     const resolvedPath = resolve(filePath);
 
-    // Defense in depth: refuse any path that escapes the inbox after join.
-    if (
-      resolvedPath !== resolvedInbox &&
-      !resolvedPath.startsWith(resolvedInbox + "/")
-    ) {
+    // Only allow strict child files of the inbox — not the inbox dir itself
+    // (e.g. join(inbox, "/") / join(inbox, "") collapsing to inboxDir) and
+    // not anything outside it.
+    const isStrictChild =
+      resolvedPath.startsWith(resolvedInbox + "/") &&
+      resolvedPath.length > resolvedInbox.length + 1;
+    if (!isStrictChild) {
       process.stderr.write(
-        `[hitl-channel] Skipping attachment (path escapes inbox): fileName=${fileName}\n`,
+        `[hitl-channel] Skipping attachment (path not a strict inbox child): fileName=${fileName}\n`,
       );
       continue;
     }


### PR DESCRIPTION
Closes #36

## Summary
File-type attachments (JSON, PDF, txt — any non-image mime) sent from the HITL phone to a Claude Code session were **silently discarded** by `processAttachments`, which only persisted `type === "image"`. Message text was delivered; the file never landed in the inbox and no warning was logged. The audit row still counted the attachment, overstating delivery.

## Changes
- **`processAttachments`**: persist every attachment with non-empty `data`; append `[Image: path]` for images and `[File: path]` for all other types
- **`sanitizeAttachmentFileName`**: basename-only + strip leading dots so phone-supplied `fileName` cannot escape the inbox (`../../evil.sh`, absolute paths, embedded `/`)
- **Stderr warnings** for skipped entries (missing/invalid `data`, path escape, decode failure) instead of silent fall-through
- **WS chat-branch audit**: use `summariseAttachments` for real `attachment_count` / `attachment_bytes` (parity with `POST /`; was hardcoded `0/0`)
- **Tests** covering AV1–AV5 (file write + marker, image regression, path traversal, missing-data warning, WS audit)

## Verification
```bash
bun test
# 122 pass, 0 fail
```

## Notes for CV
Channel MCP server loads `http_bridge.ts` once at startup — after merge, restart the channel (`/mcp reconnect` or CC session restart) before re-sharing a JSON file from the phone.

## Agent Verification (AV)
- [x] AV1: `type:"file"` writes decoded file + `[File: path]` in notification
- [x] AV2: image attachments still produce `[Image: path]` with identical bytes
- [x] AV3: traversal-hostile `fileName` confined to inbox dir
- [x] AV4: attachment without `data` skipped with stderr warning; message still delivered
- [x] AV5: WS chat-branch audit carries real attachment_count/bytes via `summariseAttachments`