### PR TITLE
docs: clarify role of commitById in ACK protocol

### DIFF
--- a/src/reply_buffer.ts
+++ b/src/reply_buffer.ts
@@ -111,6 +111,9 @@ export class ReplyBuffer {
 
   /**
    * Remove a reply from the buffer by its unique ID.
+   * This is invoked when the client successfully receives and acknowledges
+   * a message via an "ack" control frame, implementing the application-level
+   * ACK protocol to prevent message drops on reconnect.
    * Returns true if found and removed; false if already absent.
    */
   commitById(id: string): boolean {


### PR DESCRIPTION
Closes #34

This PR clarifies the documentation for ReplyBuffer's commitById method to highlight its role in the WebSocket application-level ACK protocol, ensuring reliable delivery and preventing message drops on reconnect.