### PR TITLE
Fix flat questions batch response metadata relay

### DIFF
--- a/.specs/brain/_pending/d5811fc0-cbdf-4793-a8bb-823cd1d3abfb.md
+++ b/.specs/brain/_pending/d5811fc0-cbdf-4793-a8bb-823cd1d3abfb.md
@@ -1,0 +1,25 @@
+---
+title: "Phone HTTP response metadata uses a flat envelope"
+type: lesson
+products: [hitl-channel, hitl-app]
+source: hitl-channel#38
+task_id: d5811fc0-cbdf-4793-a8bb-823cd1d3abfb
+last_updated: 2026-07-26
+---
+
+## What happened
+
+The `questions_batch_response` formatter added by hitl-channel#22 read only
+`body.metadata`. The hitl-app client has always flattened message metadata into
+the top-level HTTP `POST /` body, so live batch replies carried `type`,
+`batch_id`, and `batch_answer` beside `content` and never entered the formatter
+or the questions-batch audit branch.
+
+## Lesson
+
+Tests for phone-to-channel HTTP messages must use the client's real serialized
+wire envelope, not a hand-authored domain-model shape. The bridge now normalizes
+supported flat response fields when nested `metadata` is absent while retaining
+backward compatibility with nested senders. Regression fixtures should include
+the same top-level `id` and `timestamp` fields emitted by hitl-app so future
+contract drift is visible.

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -123,6 +123,45 @@ describe("hitl-channel HTTP Bridge", () => {
     expect(JSON.parse(lastNotification.params.meta.batch_answer)).toEqual(payload.metadata.batch_answer);
   });
 
+  it("POST / should format the phone client's flat questions_batch_response envelope", async () => {
+    lastNotification = null;
+    const payload = {
+      type: "questions_batch_response",
+      content: "Submitted 2 answers",
+      batch_id: "req-flat-820cdda6",
+      batch_answer: {
+        answers: [
+          { header: "Horizon", selected: ["Both"] },
+          { header: "Primary win", selected: ["Agents+Automations", "Required-vars"] },
+        ],
+        cancelled: false,
+      },
+      id: "phone-message-123",
+      timestamp: "2026-07-10T12:00:00.000Z",
+    };
+
+    const response = await fetch(`http://127.0.0.1:${TEST_PORT}/`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${TEST_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    expect(response.status).toBe(200);
+    expect(lastNotification).not.toBeNull();
+    expect(lastNotification.params.content).toBe(
+      "Submitted 2 answers — Horizon: [Both]; Primary win: [Agents+Automations, Required-vars]"
+    );
+    expect(lastNotification.params.meta.type).toBe("questions_batch_response");
+    expect(lastNotification.params.meta.batch_id).toBe("req-flat-820cdda6");
+    expect(lastNotification.params.meta.request_id).toBe("req-flat-820cdda6");
+    expect(JSON.parse(lastNotification.params.meta.batch_answer)).toEqual(
+      payload.batch_answer
+    );
+  });
+
   it("POST / with empty message should return 400 Bad Request", async () => {
     const response = await fetch(`http://127.0.0.1:${TEST_PORT}/`, {
       method: "POST",

--- a/src/http_bridge.ts
+++ b/src/http_bridge.ts
@@ -457,7 +457,20 @@ export function startHttpBridge(mcp: Server) {
             const senderId = String(body.sender_id ?? "unknown");
             const agentId = body.agent_id ? String(body.agent_id) : undefined;
             const attachments = body.attachments;
-            const metadata = body.metadata;
+            // The phone client flattens response metadata into the top-level
+            // POST envelope. Keep accepting the legacy nested shape while
+            // normalising the real wire shape for downstream formatting,
+            // notification metadata, and audit classification.
+            const metadata = body.metadata ?? (
+              typeof body.type === "string" && body.type !== "user_message"
+                ? {
+                    type: body.type,
+                    batch_id: body.batch_id,
+                    batch_answer: body.batch_answer,
+                    cancelled: body.cancelled,
+                  }
+                : undefined
+            );
 
             if (!message.trim() && (!attachments || attachments.length === 0)) {
               return new Response(

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,10 @@ export interface HitlMessage {
   agent_id?: string;
   attachments?: HitlAttachment[];
   metadata?: Record<string, any>;
+  type?: string;
+  batch_id?: string;
+  batch_answer?: Record<string, any>;
+  cancelled?: boolean;
 }
 
 export interface ChannelMeta {


### PR DESCRIPTION
Closes #38

## Summary
- normalize hitl-app's flat response envelope into bridge metadata when nested metadata is absent
- preserve compatibility with nested metadata senders
- restore questions batch answer formatting, request ID mapping, and audit classification for live phone responses
- add a regression fixture matching the real flat client wire shape
- record the cross-repo wire-contract lesson for brain ingestion

## Validation
- bunx tsc --noEmit
- bun test (125 passed)
- uv run pytest -v (0 Python tests collected; repository is TypeScript)
- uv run ruff check .